### PR TITLE
security: harden file permissions, fix timing attack and API key exposure

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "async-stream",
  "axum",
  "base64 0.22.1",
+ "constant_time_eq",
  "dirs 6.0.0",
  "if-addrs",
  "log",
@@ -765,6 +766,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,3 +43,4 @@ async-stream = "0.3"
 rfd = "0.15"
 if-addrs = "0.13"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+constant_time_eq = "0.3"

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -16,6 +16,7 @@ use time::OffsetDateTime;
 
 use crate::models::ExtractedAuth;
 use crate::models::PreparedOauthLogin;
+use crate::utils::private_create_new_options;
 use crate::utils::set_private_permissions;
 use crate::utils::truncate_for_error;
 
@@ -656,9 +657,7 @@ fn write_auth_file_atomically(path: &Path, contents: &[u8]) -> Result<(), String
     ));
 
     let write_result = (|| -> Result<(), String> {
-        let mut temp_file = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
+        let mut temp_file = private_create_new_options()
             .open(&temp_path)
             .map_err(|e| format!("创建临时 auth.json 失败 {}: {e}", temp_path.display()))?;
         temp_file

--- a/src-tauri/src/proxy_daemon.rs
+++ b/src-tauri/src/proxy_daemon.rs
@@ -56,7 +56,9 @@ pub async fn run_proxy_daemon(options: ProxyDaemonOptions) -> Result<(), String>
     println!("data_dir={}", options.data_dir.display());
     println!("listen=http://{}:{port}/v1", options.host);
     if let Some(api_key) = status.api_key.as_deref() {
-        println!("api_key={api_key}");
+        // 仅打印前 8 位，避免完整 API Key 写入 systemd journal / 日志文件
+        let preview = &api_key[..api_key.len().min(8)];
+        println!("api_key_preview={preview}... (full key stored in data_dir/api-proxy.key)");
     }
     println!("upstream=codex");
 

--- a/src-tauri/src/proxy_service.rs
+++ b/src-tauri/src/proxy_service.rs
@@ -53,6 +53,7 @@ use crate::store::load_store_from_path;
 use crate::store::save_store_to_path;
 use crate::usage::resolve_chatgpt_base_origin;
 use crate::utils::now_unix_seconds;
+use crate::utils::private_create_new_options;
 use crate::utils::set_private_permissions;
 use crate::utils::truncate_for_error;
 
@@ -1634,7 +1635,7 @@ fn is_authorized(headers: &HeaderMap, api_key: &str) -> bool {
         .get("x-api-key")
         .and_then(|value| value.to_str().ok())
     {
-        if value == api_key {
+        if constant_time_eq::constant_time_eq(value.as_bytes(), api_key.as_bytes()) {
             return true;
         }
     }
@@ -1644,7 +1645,9 @@ fn is_authorized(headers: &HeaderMap, api_key: &str) -> bool {
         .and_then(|value| value.to_str().ok())
     {
         if let Some(token) = value.strip_prefix("Bearer ") {
-            return token == api_key;
+            if constant_time_eq::constant_time_eq(token.as_bytes(), api_key.as_bytes()) {
+                return true;
+            }
         }
     }
 
@@ -1776,9 +1779,7 @@ fn write_private_file_atomically(path: &Path, contents: &[u8]) -> Result<(), Str
     ));
 
     let write_result = (|| -> Result<(), String> {
-        let mut temp_file = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
+        let mut temp_file = private_create_new_options()
             .open(&temp_path)
             .map_err(|error| {
                 format!("创建 API Key 临时文件失败 {}: {error}", temp_path.display())

--- a/src-tauri/src/remote_service.rs
+++ b/src-tauri/src/remote_service.rs
@@ -1494,18 +1494,18 @@ impl PreparedAuth {
                     sanitize_service_fragment(&server.id),
                     now_unix_seconds()
                 ));
-                fs::write(&temp_path, private_key).map_err(|error| {
-                    format!("写入临时 SSH 私钥文件失败 {}: {error}", temp_path.display())
-                })?;
-                #[cfg(unix)]
+                // 使用 private_create_new_options 确保文件从创建时就是 0o600 权限，
+                // 消除 fs::write + set_permissions 两步之间的 TOCTOU 窗口
                 {
-                    use std::os::unix::fs::PermissionsExt;
-                    let mut perms = fs::metadata(&temp_path)
-                        .map_err(|error| format!("读取临时 SSH 私钥文件权限失败: {error}"))?
-                        .permissions();
-                    perms.set_mode(0o600);
-                    fs::set_permissions(&temp_path, perms)
-                        .map_err(|error| format!("设置临时 SSH 私钥文件权限失败: {error}"))?;
+                    use std::io::Write as _;
+                    let mut f = crate::utils::private_create_new_options()
+                        .open(&temp_path)
+                        .map_err(|error| {
+                            format!("写入临时 SSH 私钥文件失败 {}: {error}", temp_path.display())
+                        })?;
+                    f.write_all(private_key.as_bytes()).map_err(|error| {
+                        format!("写入临时 SSH 私钥文件失败 {}: {error}", temp_path.display())
+                    })?;
                 }
                 Ok(Self {
                     temp_identity_file: Some(temp_path),

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -17,6 +17,7 @@ use crate::models::dedupe_account_variants;
 use crate::models::AccountsStore;
 use crate::models::StoredAccount;
 use crate::utils::now_unix_seconds;
+use crate::utils::private_create_new_options;
 use crate::utils::set_private_permissions;
 use crate::utils::short_account;
 
@@ -245,9 +246,7 @@ fn write_file_atomically(path: &Path, contents: &[u8]) -> Result<(), String> {
     ));
 
     let write_result = (|| -> Result<(), String> {
-        let mut temp_file = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
+        let mut temp_file = private_create_new_options()
             .open(&temp_path)
             .map_err(|e| format!("创建临时存储文件失败 {}: {e}", temp_path.display()))?;
         temp_file
@@ -315,14 +314,12 @@ fn write_store_shadow_backups(path: &Path, contents: &[u8]) -> Result<(), String
     if latest_backup.exists() {
         let latest_contents = fs::read(&latest_backup)
             .map_err(|e| format!("读取最新备份失败 {}: {e}", latest_backup.display()))?;
-        fs::write(&previous_backup, latest_contents)
+        write_private_file(&previous_backup, &latest_contents)
             .map_err(|e| format!("写入上一个备份失败 {}: {e}", previous_backup.display()))?;
-        set_private_permissions(&previous_backup);
     }
 
-    fs::write(&latest_backup, contents)
+    write_private_file(&latest_backup, contents)
         .map_err(|e| format!("写入最新备份失败 {}: {e}", latest_backup.display()))?;
-    set_private_permissions(&latest_backup);
     Ok(())
 }
 
@@ -457,6 +454,28 @@ fn is_store_backup_candidate(path: &Path) -> bool {
         || name.starts_with(".accounts.json.tmp-")
 }
 
+/// 以 0o600 权限（Unix）原子写入文件，替换 fs::write + set_private_permissions 的两步操作，
+/// 消除文件短暂对其他用户可读的窗口。
+fn write_private_file(path: &Path, contents: &[u8]) -> Result<(), std::io::Error> {
+    use std::io::Write as _;
+
+    // 若文件已存在，先截断再写；不存在则新建，均以受限权限打开
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut f = opts.open(path)?;
+    f.write_all(contents)?;
+
+    #[cfg(windows)]
+    set_private_permissions(path);
+
+    Ok(())
+}
+
 fn file_modified_at(path: &Path) -> i64 {
     fs::metadata(path)
         .ok()
@@ -477,9 +496,8 @@ fn backup_corrupted_store_file(path: &Path, raw: &str) -> Result<PathBuf, String
         .map_err(|e| format!("创建存储目录失败 {}: {e}", parent.display()))?;
 
     let backup_path = parent.join(format!("accounts.corrupt-{}.json", now_unix_seconds()));
-    fs::write(&backup_path, raw)
+    write_private_file(&backup_path, raw.as_bytes())
         .map_err(|e| format!("写入损坏备份文件失败 {}: {e}", backup_path.display()))?;
-    set_private_permissions(&backup_path);
     Ok(backup_path)
 }
 

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -38,8 +38,42 @@ pub(crate) fn set_private_permissions(path: &Path) {
         }
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        // 在 Windows 上尝试通过 icacls 移除 Everyone 的读权限，仅保留当前用户
+        if let Some(path_str) = path.to_str() {
+            let current_user = std::env::var("USERNAME").unwrap_or_default();
+            if !current_user.is_empty() {
+                let _ = std::process::Command::new("icacls")
+                    .args([
+                        path_str,
+                        "/inheritance:r",
+                        "/grant:r",
+                        &format!("{current_user}:(R,W)"),
+                    ])
+                    .output();
+            }
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
     let _ = path;
+}
+
+/// 返回用于创建私有临时文件的 OpenOptions：
+/// - Unix：以 0o600 权限创建（从一开始就限制访问，消除 TOCTOU）
+/// - 其他平台：使用默认 OpenOptions，之后再调用 set_private_permissions
+pub(crate) fn private_create_new_options() -> fs::OpenOptions {
+    let mut opts = fs::OpenOptions::new();
+    opts.create_new(true).write(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+
+    opts
 }
 
 pub(crate) fn prepare_process_path() {


### PR DESCRIPTION
## Summary

- **修复计时侧信道攻击**：`proxy_service.rs` 中的 API Key 比较改为使用 `constant_time_eq`，防止攻击者通过响应时间差推断 key 内容
- **修复 TOCTOU 竞争条件**：新增 `private_create_new_options()` 工具函数，在 Unix 上以 `mode(0o600)` 原子创建临时文件，避免文件创建后 `chmod` 前短暂对其他用户可读的窗口（涉及 `proxy_service.rs`、`auth.rs`、`store.rs`、`remote_service.rs` 中的 SSH 私钥临时文件）
- **防止 API Key 泄露至日志**：`proxy_daemon.rs` 中输出 status 时仅打印 key 的前 8 位预览，不输出完整 key
- **Windows 权限加固**：`utils.rs` 的 `set_private_permissions()` 在 Windows 上调用 `icacls` 移除 Everyone 权限，仅保留当前用户读写权限（原先为空实现）
- 新增 `constant_time_eq = "0.3"` 依赖

## 变更文件

| 文件 | 改动 |
|---|---|
| `src-tauri/Cargo.toml` | 新增 `constant_time_eq` 依赖 |
| `src-tauri/src/utils.rs` | 新增 `private_create_new_options()`，完善 Windows `set_private_permissions()` |
| `src-tauri/src/proxy_service.rs` | 常量时间 API Key 比较，原子私有临时文件 |
| `src-tauri/src/proxy_daemon.rs` | 遮蔽完整 API Key 输出 |
| `src-tauri/src/auth.rs` | 原子私有临时文件 |
| `src-tauri/src/store.rs` | 原子私有临时文件，新增 `write_private_file()` 辅助函数 |
| `src-tauri/src/remote_service.rs` | SSH 私钥临时文件原子创建（消除 TOCTOU） |

## Test plan

- [ ] macOS/Linux：确认敏感文件（auth token、API key、store、SSH key）创建后权限为 `0o600`
- [ ] Windows：确认 `icacls` 调用成功限制文件权限
- [ ] 确认代理服务功能正常（认证、转发）
- [ ] 确认日志中不再出现完整 API Key

🤖 Generated with [Claude Code](https://claude.com/claude-code)