### PR TITLE
Fix light theme status display contrast

### DIFF
--- a/src/styles/controls.css
+++ b/src/styles/controls.css
@@ -952,6 +952,7 @@
 }
 
 .modeGroup > button.primary {
+  color: var(--ink);
   background: color-mix(in srgb, var(--card) 84%, var(--surface-tint) 16%);
   border: 1px solid color-mix(in srgb, var(--brand-hot) 26%, var(--line) 74%);
   box-shadow:


### PR DESCRIPTION
﻿## Summary
- Fix the light-theme contrast for the Settings page status display segmented control.
- Keep the change scoped to `.modeGroup > button.primary` so global primary buttons continue using white text on blue backgrounds.

## Root Cause
The selected segmented-control button uses the global `primary` class. In light theme, the segmented control selected background is near-white, but global `button.primary` forces white text, making the selected label hard to read.

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run tauri -- build --bundles nsis --config <temp config disabling updater artifacts> --ci`
- Installed the generated NSIS package and manually checked the installed app in light/dark themes.

Closes #138
