### PR TITLE
[EN/ZH] Add reset credit card expiry display / 增加重置卡过期时间显示

### DIFF
--- a/src-tauri/src/account_service.rs
+++ b/src-tauri/src/account_service.rs
@@ -1944,6 +1944,7 @@ mod tests {
                 reset_at: Some(30),
             }),
             credits: None,
+            reset_credits: None,
         }
     }
 
@@ -1963,6 +1964,7 @@ mod tests {
             five_hour: None,
             one_week: None,
             credits: None,
+            reset_credits: None,
         };
         let resolved = resolve_usage_first_plan_type(Some(&usage), Some("pro".to_string()));
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -150,6 +150,8 @@ pub(crate) struct UsageSnapshot {
     pub(crate) five_hour: Option<UsageWindow>,
     pub(crate) one_week: Option<UsageWindow>,
     pub(crate) credits: Option<CreditSnapshot>,
+    #[serde(default)]
+    pub(crate) reset_credits: Option<ResetCreditsSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -166,6 +168,21 @@ pub(crate) struct CreditSnapshot {
     pub(crate) has_credits: bool,
     pub(crate) unlimited: bool,
     pub(crate) balance: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResetCreditsSnapshot {
+    pub(crate) available_count: Option<i64>,
+    #[serde(default)]
+    pub(crate) credits: Vec<ResetCredit>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResetCredit {
+    pub(crate) granted_at: Option<i64>,
+    pub(crate) expires_at: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -868,6 +885,7 @@ mod tests {
                 reset_at: Some(30),
             }),
             credits: None,
+            reset_credits: None,
         }
     }
 
@@ -1079,6 +1097,7 @@ mod tests {
                 five_hour: None,
                 one_week: None,
                 credits: None,
+                reset_credits: None,
             }),
             usage_error: None,
             auth_refresh_blocked: false,

--- a/src-tauri/src/proxy_service.rs
+++ b/src-tauri/src/proxy_service.rs
@@ -7051,6 +7051,7 @@ mod tests {
                     reset_at: None,
                 }),
                 credits: None,
+                reset_credits: None,
             }),
             auth_refresh_blocked,
             auth_refresh_error: None,

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -3,6 +3,8 @@ use std::error::Error as StdError;
 
 use crate::app_paths;
 use crate::models::CreditSnapshot;
+use crate::models::ResetCredit;
+use crate::models::ResetCreditsSnapshot;
 use crate::models::UsageSnapshot;
 use crate::models::UsageWindow;
 use crate::utils::now_unix_seconds;
@@ -11,6 +13,7 @@ use crate::utils::truncate_for_error;
 const DEFAULT_CHATGPT_BASE_URL: &str = "https://chatgpt.com";
 const CODEX_USAGE_PATH: &str = "/api/codex/usage";
 const WHAM_USAGE_PATH: &str = "/wham/usage";
+const WHAM_RESET_CREDITS_PATH: &str = "/wham/rate-limit-reset-credits";
 const BACKEND_API_PREFIX: &str = "/backend-api";
 
 #[derive(Debug, Deserialize)]
@@ -92,7 +95,8 @@ pub(crate) async fn fetch_usage_snapshot(
                 continue;
             }
         };
-        return Ok(map_usage_payload(payload));
+        let reset_credits = fetch_reset_credits_snapshot(&client, access_token, account_id).await;
+        return Ok(map_usage_payload(payload, reset_credits));
     }
 
     if errors.is_empty() {
@@ -131,6 +135,35 @@ fn resolve_usage_urls() -> Vec<String> {
 
     candidates.push("https://chatgpt.com/backend-api/wham/usage".to_string());
     candidates.push(format!("https://chatgpt.com{CODEX_USAGE_PATH}"));
+
+    let mut deduped = Vec::new();
+    for url in candidates {
+        if !deduped.iter().any(|existing| existing == &url) {
+            deduped.push(url);
+        }
+    }
+    deduped
+}
+
+fn resolve_reset_credit_urls() -> Vec<String> {
+    let normalized = resolve_chatgpt_base_origin();
+    let mut candidates = Vec::new();
+
+    if let Some(origin) = normalized.strip_suffix(BACKEND_API_PREFIX) {
+        candidates.push(format!("{normalized}{WHAM_RESET_CREDITS_PATH}"));
+        candidates.push(format!(
+            "{origin}{BACKEND_API_PREFIX}{WHAM_RESET_CREDITS_PATH}"
+        ));
+    } else {
+        candidates.push(format!(
+            "{normalized}{BACKEND_API_PREFIX}{WHAM_RESET_CREDITS_PATH}"
+        ));
+        candidates.push(format!("{normalized}{WHAM_RESET_CREDITS_PATH}"));
+    }
+
+    candidates.push(format!(
+        "https://chatgpt.com{BACKEND_API_PREFIX}{WHAM_RESET_CREDITS_PATH}"
+    ));
 
     let mut deduped = Vec::new();
     for url in candidates {
@@ -180,7 +213,68 @@ fn read_chatgpt_base_url_from_config() -> Option<String> {
     None
 }
 
-fn map_usage_payload(payload: UsageApiResponse) -> UsageSnapshot {
+async fn fetch_reset_credits_snapshot(
+    client: &reqwest::Client,
+    access_token: &str,
+    account_id: &str,
+) -> Option<ResetCreditsSnapshot> {
+    let mut errors = Vec::new();
+
+    for reset_url in resolve_reset_credit_urls() {
+        let response = match client
+            .get(&reset_url)
+            .header("Authorization", format!("Bearer {access_token}"))
+            .header("ChatGPT-Account-Id", account_id)
+            .header("Accept", "application/json")
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(err) => {
+                errors.push(format!("{reset_url} -> {}", format_reqwest_error(&err)));
+                continue;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            errors.push(format!(
+                "{reset_url} -> {status}: {}",
+                truncate_for_error(&body, 140)
+            ));
+            continue;
+        }
+
+        let payload: serde_json::Value = match response.json().await {
+            Ok(payload) => payload,
+            Err(err) => {
+                errors.push(format!("{reset_url} -> 解析返回失败: {err}"));
+                continue;
+            }
+        };
+
+        return Some(map_reset_credits_payload(payload));
+    }
+
+    if !errors.is_empty() {
+        log::debug!(
+            "获取 Codex 重置卡失败: {}",
+            errors
+                .iter()
+                .take(2)
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(" | ")
+        );
+    }
+    None
+}
+
+fn map_usage_payload(
+    payload: UsageApiResponse,
+    reset_credits: Option<ResetCreditsSnapshot>,
+) -> UsageSnapshot {
     let mut windows: Vec<UsageWindowRaw> = Vec::new();
 
     if let Some(rate_limit) = payload.rate_limit {
@@ -218,6 +312,92 @@ fn map_usage_payload(payload: UsageApiResponse) -> UsageSnapshot {
             unlimited: credit.unlimited,
             balance: credit.balance,
         }),
+        reset_credits,
+    }
+}
+
+fn map_reset_credits_payload(payload: serde_json::Value) -> ResetCreditsSnapshot {
+    let available_count = payload
+        .get("available_count")
+        .or_else(|| payload.get("availableCount"))
+        .and_then(parse_optional_i64);
+
+    let credits = payload
+        .get("credits")
+        .and_then(serde_json::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| ResetCredit {
+                    granted_at: get_timestamp_field(
+                        item,
+                        &[
+                            "granted_at",
+                            "grantedAt",
+                            "created_at",
+                            "createdAt",
+                            "obtained_at",
+                            "obtainedAt",
+                        ],
+                    ),
+                    expires_at: get_timestamp_field(
+                        item,
+                        &[
+                            "expires_at",
+                            "expiresAt",
+                            "expiration",
+                            "expire_at",
+                            "expireAt",
+                        ],
+                    ),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    ResetCreditsSnapshot {
+        available_count,
+        credits,
+    }
+}
+
+fn get_timestamp_field(value: &serde_json::Value, keys: &[&str]) -> Option<i64> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(parse_optional_i64))
+}
+
+fn parse_optional_i64(value: &serde_json::Value) -> Option<i64> {
+    if let Some(number) = value.as_i64() {
+        return Some(normalize_epoch_seconds(number));
+    }
+
+    if let Some(number) = value.as_u64() {
+        return i64::try_from(number).ok().map(normalize_epoch_seconds);
+    }
+
+    if let Some(text) = value
+        .as_str()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        if let Ok(number) = text.parse::<i64>() {
+            return Some(normalize_epoch_seconds(number));
+        }
+        if let Ok(parsed) =
+            time::OffsetDateTime::parse(text, &time::format_description::well_known::Rfc3339)
+        {
+            return Some(parsed.unix_timestamp());
+        }
+    }
+
+    None
+}
+
+fn normalize_epoch_seconds(value: i64) -> i64 {
+    if value > 10_000_000_000 {
+        value / 1000
+    } else {
+        value
     }
 }
 
@@ -237,5 +417,52 @@ fn to_usage_window(window: UsageWindowRaw) -> UsageWindow {
         used_percent: window.used_percent,
         window_seconds: window.limit_window_seconds,
         reset_at: Some(window.reset_at),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_reset_credits_payload;
+    use serde_json::json;
+
+    #[test]
+    fn reset_credits_payload_accepts_common_timestamp_shapes() {
+        let snapshot = map_reset_credits_payload(json!({
+            "available_count": 2,
+            "credits": [
+                {
+                    "granted_at": 1_797_392_400,
+                    "expires_at": 1_799_984_400_000i64
+                },
+                {
+                    "createdAt": "2026-12-15T10:00:00Z",
+                    "expiresAt": "2027-01-14T10:00:00Z"
+                }
+            ]
+        }));
+
+        assert_eq!(snapshot.available_count, Some(2));
+        assert_eq!(snapshot.credits.len(), 2);
+        assert_eq!(snapshot.credits[0].granted_at, Some(1_797_392_400));
+        assert_eq!(snapshot.credits[0].expires_at, Some(1_799_984_400));
+        assert_eq!(snapshot.credits[1].granted_at, Some(1_797_328_800));
+        assert_eq!(snapshot.credits[1].expires_at, Some(1_799_920_800));
+    }
+
+    #[test]
+    fn reset_credits_payload_accepts_camel_case_available_count() {
+        let snapshot = map_reset_credits_payload(json!({
+            "availableCount": "1",
+            "credits": [
+                {
+                    "obtained_at": "1797392400",
+                    "expireAt": null
+                }
+            ]
+        }));
+
+        assert_eq!(snapshot.available_count, Some(1));
+        assert_eq!(snapshot.credits[0].granted_at, Some(1_797_392_400));
+        assert_eq!(snapshot.credits[0].expires_at, None);
     }
 }

--- a/src/components/AccountsGrid.tsx
+++ b/src/components/AccountsGrid.tsx
@@ -50,6 +50,11 @@ type UiCopy = {
   weekUsage: string;
   remainingSuffix: (value: string) => string;
   resetTime: string;
+  resetCreditsTitle: string;
+  resetCreditsAvailable: (count: number | null) => string;
+  resetCreditsExpiresAt: string;
+  resetCreditsExpand: (hiddenCount: number) => string;
+  resetCreditsCollapse: string;
   planType: string;
   recentSwitches: string;
   switchRecordAction: string;
@@ -200,6 +205,11 @@ function getUiCopy(locale: string): UiCopy {
       weekUsage: "周使用率",
       remainingSuffix: (value) => `剩余 ${value}`,
       resetTime: "重置时间",
+      resetCreditsTitle: "重置卡",
+      resetCreditsAvailable: (count) => (count === null ? "可用数量未知" : `可用 ${count} 张`),
+      resetCreditsExpiresAt: "过期时间（系统本地时间）",
+      resetCreditsExpand: (hiddenCount) => `展开 ${hiddenCount} 张`,
+      resetCreditsCollapse: "收起",
       planType: "套餐类型",
       recentSwitches: "最近切换记录",
       switchRecordAction: "切换到此账号",
@@ -239,6 +249,11 @@ function getUiCopy(locale: string): UiCopy {
     weekUsage: "Weekly usage",
     remainingSuffix: (value) => `${value} remaining`,
     resetTime: "Reset time",
+    resetCreditsTitle: "Reset cards",
+    resetCreditsAvailable: (count) => (count === null ? "Available count unknown" : `${count} available`),
+    resetCreditsExpiresAt: "Expires (system local time)",
+    resetCreditsExpand: (hiddenCount) => `Show ${hiddenCount} more`,
+    resetCreditsCollapse: "Show less",
     planType: "Plan",
     recentSwitches: "Recent switches",
     switchRecordAction: "Switched to this account",
@@ -304,6 +319,11 @@ function formatFullDate(epochSec: number | null | undefined, locale: string, emp
   });
 }
 
+function hasResetCredits(account: AccountSummary): boolean {
+  const resetCredits = account.usage?.resetCredits;
+  return Boolean(resetCredits && (resetCredits.availableCount !== null || resetCredits.credits.length > 0));
+}
+
 function eventTimestampToUnixSeconds(timestamp: number): number {
   const timeOrigin = typeof performance === "undefined" ? 0 : performance.timeOrigin;
   return Math.floor((timeOrigin + timestamp) / 1000);
@@ -346,6 +366,68 @@ function UsageMeter({
         {label} {percent(value)} {text.remainingSuffix(percent(remaining))}
       </span>
     </div>
+  );
+}
+
+function ResetCreditsSection({
+  account,
+  expanded,
+  locale,
+  text,
+  onToggle,
+}: {
+  account: AccountSummary;
+  expanded: boolean;
+  locale: string;
+  text: UiCopy;
+  onToggle: () => void;
+}) {
+  const resetCredits = account.usage?.resetCredits;
+  if (!resetCredits || !hasResetCredits(account)) {
+    return null;
+  }
+
+  const visibleCredits = expanded ? resetCredits.credits : resetCredits.credits.slice(0, 2);
+  const hiddenCount = Math.max(0, resetCredits.credits.length - visibleCredits.length);
+
+  return (
+    <section className="detailCard resetCreditsCard">
+      <div className="detailSectionTitle">
+        <h3>{text.resetCreditsTitle}</h3>
+        <span className="resetCreditsCount">
+          {text.resetCreditsAvailable(resetCredits.availableCount ?? null)}
+        </span>
+      </div>
+      {visibleCredits.length > 0 ? (
+        <div className="resetCreditList">
+          {visibleCredits.map((credit, index) => (
+            <div
+              className="resetCreditItem"
+              key={`${credit.grantedAt ?? "unknown"}-${credit.expiresAt ?? "unknown"}-${index}`}
+            >
+              <span className="resetCreditIndex">{index + 1}</span>
+              <div>
+                <span>{text.resetCreditsExpiresAt}</span>
+                <strong>{formatFullDate(credit.expiresAt, locale, text.emptyValue)}</strong>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {resetCredits.credits.length > 2 ? (
+        <button
+          className="ghost resetCreditsToggle"
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+        >
+          <svg className={expanded ? "resetCreditsToggleIcon isExpanded" : "resetCreditsToggleIcon"} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+          <span>{expanded ? text.resetCreditsCollapse : text.resetCreditsExpand(hiddenCount)}</span>
+        </button>
+      ) : null}
+    </section>
   );
 }
 
@@ -519,6 +601,7 @@ export function AccountsGrid({
   const [openMenuAccountId, setOpenMenuAccountId] = useState<string | null>(null);
   const openMenuRootRef = useRef<HTMLDivElement | null>(null);
   const [switchRecords, setSwitchRecords] = useState<SwitchRecord[]>([]);
+  const [expandedResetCreditsByAccount, setExpandedResetCreditsByAccount] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     if (!openMenuAccountId || typeof document === "undefined") {
@@ -679,6 +762,13 @@ export function AccountsGrid({
       ...current,
     ].slice(0, 5));
     onSwitch(account);
+  };
+
+  const toggleResetCredits = (accountId: string) => {
+    setExpandedResetCreditsByAccount((current) => ({
+      ...current,
+      [accountId]: !current[accountId],
+    }));
   };
 
   return (
@@ -1022,6 +1112,14 @@ export function AccountsGrid({
                 </strong>
               </div>
             </section>
+
+            <ResetCreditsSection
+              account={selectedRow.account}
+              expanded={Boolean(expandedResetCreditsByAccount[selectedRow.account.id])}
+              locale={locale}
+              text={text}
+              onToggle={() => toggleResetCredits(selectedRow.account.id)}
+            />
 
             <section className="detailCard recentSwitchCard">
               <div className="detailSectionTitle">

--- a/src/styles/accounts.css
+++ b/src/styles/accounts.css
@@ -805,6 +805,7 @@ button.accountTokenExportButton {
 .accountDetailPanel {
   padding: 16px;
   display: grid;
+  grid-auto-rows: max-content;
   align-content: start;
   gap: 20px;
   overflow: auto;
@@ -946,6 +947,98 @@ button.accountTokenExportButton {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.resetCreditsCard {
+  gap: 12px;
+}
+
+.resetCreditsCount {
+  min-height: 26px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid color-mix(in srgb, var(--brand) 20%, var(--line) 80%);
+  border-radius: 8px;
+  padding: 0 9px;
+  color: color-mix(in srgb, var(--brand) 82%, var(--ink) 18%);
+  background: color-mix(in srgb, var(--brand-soft) 68%, transparent);
+  font: 850 0.66rem/1 var(--font-ui);
+  white-space: nowrap;
+}
+
+.resetCreditList {
+  display: grid;
+  gap: 8px;
+}
+
+.resetCreditItem {
+  min-width: 0;
+  min-height: 54px;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  border: 1px solid color-mix(in srgb, var(--line) 80%, var(--brand) 20%);
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--card) 92%, var(--surface-tint) 8%);
+}
+
+.resetCreditIndex {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: var(--brand);
+  background: color-mix(in srgb, var(--brand-soft) 78%, transparent);
+  font: 850 0.76rem/1 var(--font-mono);
+}
+
+.resetCreditItem div {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.resetCreditItem span:not(.resetCreditIndex) {
+  color: var(--subtle);
+  font: 750 0.66rem/1 var(--font-ui);
+}
+
+.resetCreditItem strong {
+  min-width: 0;
+  color: var(--ink);
+  font: 760 0.78rem/1.2 var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.resetCreditsToggle {
+  min-height: 34px;
+  justify-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border-radius: 10px;
+  color: color-mix(in srgb, var(--brand) 76%, var(--ink) 24%);
+  font: 850 0.72rem/1 var(--font-ui);
+}
+
+.resetCreditsToggleIcon {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 140ms ease;
+}
+
+.resetCreditsToggleIcon.isExpanded {
+  transform: rotate(180deg);
 }
 
 .recentSwitchList {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -357,6 +357,14 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .resetCreditItem {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+
+  .resetCreditItem div {
+    grid-column: 2;
+  }
+
   .proxySectionHeader,
   .cloudflaredToolbar,
   .cloudflaredInstallCard,

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -12,12 +12,23 @@ export type CreditSnapshot = {
   balance: string | null;
 };
 
+export type ResetCredit = {
+  grantedAt: number | null;
+  expiresAt: number | null;
+};
+
+export type ResetCreditsSnapshot = {
+  availableCount: number | null;
+  credits: ResetCredit[];
+};
+
 export type UsageSnapshot = {
   fetchedAt: number;
   planType: string | null;
   fiveHour: UsageWindow | null;
   oneWeek: UsageWindow | null;
   credits: CreditSnapshot | null;
+  resetCredits: ResetCreditsSnapshot | null;
 };
 
 export type CodexTokenTotals = {


### PR DESCRIPTION
## English

### Summary
- Fetch Codex reset credit cards from the WHAM reset-credit endpoint.
- Add reset credit count and expiry timestamps to usage snapshots.
- Show reset card expiry times in the account detail sidebar using the system local timezone.
- Keep the original sidebar reset-time section unchanged.
- Show two reset cards by default and add expand/collapse for longer reset-card lists.

### Validation
- `npm run build`
- `git diff --check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`

### Notes
- The expiry time comes from the upstream `expires_at` field and is formatted by the client in the system local timezone.
- Related to #136, but this PR only covers reset credit card count and expiry display.

## 中文

### 摘要
- 从 WHAM 重置卡接口获取 Codex 重置卡信息。
- 在用量快照中增加重置卡数量和过期时间戳。
- 在账号详情侧边栏按系统本地时区显示重置卡过期时间。
- 保持原有侧边栏重置时间区域不变。
- 默认显示两张重置卡，更多重置卡时支持展开/收起。

### 验证
- `npm run build`
- `git diff --check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`

### 说明
- 过期时间来自上游 `expires_at` 字段，由客户端按系统本地时区格式化显示。
- 关联 #136，但本 PR 只覆盖重置卡数量和过期时间展示。
<img width="480" height="743" alt="image" src="https://github.com/user-attachments/assets/ee958f91-f59b-48f0-9868-8a362a067059" />
