### PR TITLE
perf(proxy): reduce disk I/O and inactive UI work

### DIFF
--- a/src-tauri/proxyd/Cargo.lock
+++ b/src-tauri/proxyd/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +210,7 @@ dependencies = [
  "if-addrs",
  "log",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -358,6 +371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +525,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -512,6 +546,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -810,6 +853,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +978,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1167,6 +1227,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1823,6 +1897,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/src-tauri/proxyd/Cargo.toml
+++ b/src-tauri/proxyd/Cargo.toml
@@ -26,3 +26,4 @@ sha2 = "0.10"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
 toml_edit = "0.22"
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src-tauri/src/proxy_service.rs
+++ b/src-tauri/src/proxy_service.rs
@@ -12,8 +12,10 @@ use std::path::PathBuf;
 use std::pin::Pin;
 #[cfg(target_os = "macos")]
 use std::process::Command;
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::thread::JoinHandle as ThreadJoinHandle;
 
 use async_stream::stream;
 use axum::body::Body;
@@ -42,6 +44,9 @@ use futures_util::SinkExt;
 use futures_util::Stream;
 use futures_util::StreamExt;
 use if_addrs::IfAddr;
+use rusqlite::params;
+use rusqlite::Connection;
+use rusqlite::OptionalExtension;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
@@ -164,10 +169,11 @@ const RESPONSE_MODEL_NORMALIZATIONS: &[(&str, &str)] = &[
 ];
 const UNSUPPORTED_RESPONSES_REQUEST_FIELDS: &[&str] = &["metadata", "prompt_cache_retention"];
 const API_PROXY_USAGE_FILE_NAME: &str = "api-proxy-usage.json";
+const API_PROXY_USAGE_DATABASE_FILE_NAME: &str = "api-proxy-usage.sqlite3";
+const API_PROXY_USAGE_LEGACY_MIGRATION_KEY: &str = "legacy-json-v1";
 const API_PROXY_USAGE_STORE_VERSION: u8 = 1;
 const API_PROXY_KEYS_FILE_NAME: &str = "api-proxy-keys.json";
 const API_PROXY_KEYS_STORE_VERSION: u8 = 1;
-const API_PROXY_USAGE_RETENTION_SECONDS: i64 = 30 * 24 * 60 * 60;
 const API_PROXY_USAGE_RANGE_1H_SECONDS: i64 = 60 * 60;
 const API_PROXY_USAGE_RANGE_24H_SECONDS: i64 = 24 * 60 * 60;
 const API_PROXY_USAGE_RANGE_7D_SECONDS: i64 = 7 * 24 * 60 * 60;
@@ -202,6 +208,7 @@ pub(crate) struct ProxyStorageContext {
     pub(crate) data_dir: PathBuf,
     pub(crate) store_lock: Arc<tokio::sync::Mutex<()>>,
     pub(crate) auth_refresh_lock: Arc<tokio::sync::Mutex<()>>,
+    pub(crate) usage_writer: Arc<tokio::sync::Mutex<Option<ApiProxyUsageWriter>>>,
     pub(crate) sync_active_auth_on_refresh: bool,
 }
 
@@ -266,6 +273,58 @@ impl Default for ApiProxyUsageStore {
             version: API_PROXY_USAGE_STORE_VERSION,
             updated_at: 0,
             events: Vec::new(),
+        }
+    }
+}
+
+pub(crate) struct ApiProxyUsageWriter {
+    sender: Option<mpsc::Sender<ApiProxyUsageCommand>>,
+    thread: Option<ThreadJoinHandle<()>>,
+}
+
+enum ApiProxyUsageCommand {
+    Append(ApiProxyUsageEvent),
+    QueryKeyLogs {
+        limit: usize,
+        reply: oneshot::Sender<Result<Vec<ApiProxyKeyUsageLogEntry>, String>>,
+    },
+    QueryStats {
+        now: i64,
+        range_seconds: i64,
+        reply: oneshot::Sender<Result<ApiProxyUsageStats, String>>,
+    },
+    Clear {
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+}
+
+impl ApiProxyUsageWriter {
+    fn start(data_dir: PathBuf) -> Result<Self, String> {
+        let (sender, receiver) = mpsc::channel();
+        let thread = std::thread::Builder::new()
+            .name("api-proxy-usage-writer".to_string())
+            .spawn(move || run_api_proxy_usage_writer(data_dir, receiver))
+            .map_err(|error| format!("Failed to start API proxy usage writer: {error}"))?;
+
+        Ok(Self {
+            sender: Some(sender),
+            thread: Some(thread),
+        })
+    }
+
+    fn sender(&self) -> Result<mpsc::Sender<ApiProxyUsageCommand>, String> {
+        self.sender
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| "API proxy usage writer is closed".to_string())
+    }
+}
+
+impl Drop for ApiProxyUsageWriter {
+    fn drop(&mut self) {
+        self.sender.take();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
         }
     }
 }
@@ -492,6 +551,7 @@ pub(crate) fn new_proxy_storage_context(
         data_dir,
         store_lock,
         auth_refresh_lock,
+        usage_writer: Arc::new(tokio::sync::Mutex::new(None)),
         sync_active_auth_on_refresh,
     }
 }
@@ -501,12 +561,14 @@ fn app_proxy_storage_context(
     app: &AppHandle,
     state: &AppState,
 ) -> Result<ProxyStorageContext, String> {
-    Ok(new_proxy_storage_context(
+    let mut storage = new_proxy_storage_context(
         app_data_dir(app)?,
         state.store_lock.clone(),
         state.auth_operation_lock.clone(),
         true,
-    ))
+    );
+    storage.usage_writer = state.api_proxy_usage_writer.clone();
+    Ok(storage)
 }
 
 #[cfg(feature = "desktop")]
@@ -719,40 +781,15 @@ pub(crate) async fn get_api_proxy_key_usage_logs_with_storage(
     storage: &ProxyStorageContext,
     limit: Option<usize>,
 ) -> Result<Vec<ApiProxyKeyUsageLogEntry>, String> {
-    let now = now_unix_seconds();
     let limit = limit.unwrap_or(200).clamp(1, 1_000);
-    let _guard = storage.store_lock.lock().await;
-    let path = api_proxy_usage_path(storage)?;
-    let should_scrub_legacy_fields = api_proxy_usage_store_has_legacy_private_fields(&path);
-    let mut store = load_api_proxy_usage_store_from_path(&path)?;
-    if prune_api_proxy_usage_events(&mut store.events, now) || should_scrub_legacy_fields {
-        store.updated_at = now;
-        save_api_proxy_usage_store_to_path(&path, &store)?;
-    }
-
-    let mut entries = store
-        .events
-        .into_iter()
-        .filter(|event| event.key_id.is_some() || event.key_label.is_some())
-        .map(|event| ApiProxyKeyUsageLogEntry {
-            timestamp: event.timestamp,
-            key_id: event.key_id,
-            key_label: event.key_label,
-            model: if event.model.trim().is_empty() {
-                "unknown".to_string()
-            } else {
-                event.model
-            },
-            route: event.route,
-            reasoning_effort: event.reasoning_effort,
-            service_tier: event.service_tier,
-            calls: event.calls.max(0),
-            tokens: event.tokens.max(0),
-        })
-        .collect::<Vec<_>>();
-    entries.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
-    entries.truncate(limit);
-    Ok(entries)
+    let sender = api_proxy_usage_sender(storage).await?;
+    let (reply, response) = oneshot::channel();
+    sender
+        .send(ApiProxyUsageCommand::QueryKeyLogs { limit, reply })
+        .map_err(|_| "API proxy usage writer is unavailable".to_string())?;
+    response
+        .await
+        .map_err(|_| "API proxy usage query was interrupted".to_string())?
 }
 
 #[cfg(feature = "desktop")]
@@ -771,20 +808,18 @@ pub(crate) async fn get_api_proxy_usage_stats_with_storage(
 ) -> Result<ApiProxyUsageStats, String> {
     let now = now_unix_seconds();
     let range_seconds = normalize_api_proxy_usage_range_seconds(range_seconds);
-    let _guard = storage.store_lock.lock().await;
-    let path = api_proxy_usage_path(storage)?;
-    let should_scrub_legacy_fields = api_proxy_usage_store_has_legacy_private_fields(&path);
-    let mut store = load_api_proxy_usage_store_from_path(&path)?;
-    if prune_api_proxy_usage_events(&mut store.events, now) || should_scrub_legacy_fields {
-        store.updated_at = now;
-        save_api_proxy_usage_store_to_path(&path, &store)?;
-    }
-
-    Ok(build_api_proxy_usage_stats(
-        &store.events,
-        now,
-        range_seconds,
-    ))
+    let sender = api_proxy_usage_sender(storage).await?;
+    let (reply, response) = oneshot::channel();
+    sender
+        .send(ApiProxyUsageCommand::QueryStats {
+            now,
+            range_seconds,
+            reply,
+        })
+        .map_err(|_| "API proxy usage writer is unavailable".to_string())?;
+    response
+        .await
+        .map_err(|_| "API proxy usage query was interrupted".to_string())?
 }
 
 #[cfg(feature = "desktop")]
@@ -799,14 +834,14 @@ pub(crate) async fn clear_api_proxy_usage_stats_internal(
 pub(crate) async fn clear_api_proxy_usage_stats_with_storage(
     storage: &ProxyStorageContext,
 ) -> Result<(), String> {
-    let now = now_unix_seconds();
-    let _guard = storage.store_lock.lock().await;
-    let path = api_proxy_usage_path(storage)?;
-    let store = ApiProxyUsageStore {
-        updated_at: now,
-        ..ApiProxyUsageStore::default()
-    };
-    save_api_proxy_usage_store_to_path(&path, &store)
+    let sender = api_proxy_usage_sender(storage).await?;
+    let (reply, response) = oneshot::channel();
+    sender
+        .send(ApiProxyUsageCommand::Clear { reply })
+        .map_err(|_| "API proxy usage writer is unavailable".to_string())?;
+    response
+        .await
+        .map_err(|_| "API proxy usage clear was interrupted".to_string())?
 }
 
 #[cfg(feature = "desktop")]
@@ -5303,8 +5338,18 @@ fn sanitize_api_proxy_named_options(values: Vec<String>, allowed: &[&str]) -> Ve
         .collect()
 }
 
-fn api_proxy_usage_path(storage: &ProxyStorageContext) -> Result<PathBuf, String> {
-    Ok(storage.data_dir.join(API_PROXY_USAGE_FILE_NAME))
+fn api_proxy_usage_database_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(API_PROXY_USAGE_DATABASE_FILE_NAME)
+}
+
+async fn api_proxy_usage_sender(
+    storage: &ProxyStorageContext,
+) -> Result<mpsc::Sender<ApiProxyUsageCommand>, String> {
+    let mut writer = storage.usage_writer.lock().await;
+    if writer.is_none() {
+        *writer = Some(ApiProxyUsageWriter::start(storage.data_dir.clone())?);
+    }
+    writer.as_ref().expect("usage writer initialized").sender()
 }
 
 async fn record_api_proxy_call_success(
@@ -5438,28 +5483,33 @@ fn api_proxy_usage_event(
 
 async fn append_api_proxy_usage_event(
     storage: &ProxyStorageContext,
-    mut event: ApiProxyUsageEvent,
+    event: ApiProxyUsageEvent,
 ) -> Result<(), String> {
+    let Some(event) = normalize_api_proxy_usage_event(event, now_unix_seconds()) else {
+        return Ok(());
+    };
+    api_proxy_usage_sender(storage)
+        .await?
+        .send(ApiProxyUsageCommand::Append(event))
+        .map_err(|_| "API proxy usage writer is unavailable".to_string())
+}
+
+fn normalize_api_proxy_usage_event(
+    mut event: ApiProxyUsageEvent,
+    now: i64,
+) -> Option<ApiProxyUsageEvent> {
     event.calls = event.calls.max(0);
     event.tokens = event.tokens.max(0);
     if event.calls == 0 && event.tokens == 0 {
-        return Ok(());
+        return None;
     }
     if event.model.trim().is_empty() {
         event.model = "unknown".to_string();
     }
-    let now = now_unix_seconds();
     if event.timestamp <= 0 {
         event.timestamp = now;
     }
-
-    let _guard = storage.store_lock.lock().await;
-    let path = api_proxy_usage_path(storage)?;
-    let mut store = load_api_proxy_usage_store_from_path(&path)?;
-    store.events.push(event);
-    prune_api_proxy_usage_events(&mut store.events, now);
-    store.updated_at = now;
-    save_api_proxy_usage_store_to_path(&path, &store)
+    Some(event)
 }
 
 fn load_api_proxy_usage_store_from_path(path: &Path) -> Result<ApiProxyUsageStore, String> {
@@ -5489,34 +5539,295 @@ fn load_api_proxy_usage_store_from_path(path: &Path) -> Result<ApiProxyUsageStor
     }
 }
 
-fn api_proxy_usage_store_has_legacy_private_fields(path: &Path) -> bool {
-    if !path.exists() {
-        return false;
+fn run_api_proxy_usage_writer(data_dir: PathBuf, receiver: mpsc::Receiver<ApiProxyUsageCommand>) {
+    let mut connection = match open_api_proxy_usage_database(&data_dir) {
+        Ok(connection) => connection,
+        Err(error) => {
+            log::warn!("API proxy usage database unavailable: {error}");
+            reject_api_proxy_usage_commands(receiver, &error);
+            return;
+        }
+    };
+    let mut pending = None;
+
+    loop {
+        let command = match pending.take().or_else(|| receiver.recv().ok()) {
+            Some(command) => command,
+            None => break,
+        };
+
+        match command {
+            ApiProxyUsageCommand::Append(first) => {
+                let mut events = vec![first];
+                while events.len() < 256 {
+                    match receiver.try_recv() {
+                        Ok(ApiProxyUsageCommand::Append(event)) => events.push(event),
+                        Ok(command) => {
+                            pending = Some(command);
+                            break;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                if let Err(error) = insert_api_proxy_usage_events(&mut connection, &events) {
+                    log::warn!("Failed to persist API proxy usage: {error}");
+                }
+            }
+            ApiProxyUsageCommand::QueryKeyLogs { limit, reply } => {
+                let _ = reply.send(query_api_proxy_key_usage_logs(&connection, limit));
+            }
+            ApiProxyUsageCommand::QueryStats {
+                now,
+                range_seconds,
+                reply,
+            } => {
+                let _ = reply.send(query_api_proxy_usage_stats(&connection, now, range_seconds));
+            }
+            ApiProxyUsageCommand::Clear { reply } => {
+                let result = connection
+                    .execute("DELETE FROM api_proxy_usage_events", [])
+                    .map(|_| ())
+                    .map_err(|error| format!("Failed to clear API proxy usage: {error}"));
+                let _ = reply.send(result);
+            }
+        }
+    }
+}
+
+fn reject_api_proxy_usage_commands(receiver: mpsc::Receiver<ApiProxyUsageCommand>, error: &str) {
+    for command in receiver {
+        match command {
+            ApiProxyUsageCommand::Append(_) => {}
+            ApiProxyUsageCommand::QueryKeyLogs { reply, .. } => {
+                let _ = reply.send(Err(error.to_string()));
+            }
+            ApiProxyUsageCommand::QueryStats { reply, .. } => {
+                let _ = reply.send(Err(error.to_string()));
+            }
+            ApiProxyUsageCommand::Clear { reply } => {
+                let _ = reply.send(Err(error.to_string()));
+            }
+        }
+    }
+}
+
+fn open_api_proxy_usage_database(data_dir: &Path) -> Result<Connection, String> {
+    fs::create_dir_all(data_dir).map_err(|error| {
+        format!(
+            "Failed to create API proxy usage directory {}: {error}",
+            data_dir.display()
+        )
+    })?;
+    let database_path = api_proxy_usage_database_path(data_dir);
+    let mut connection = Connection::open(&database_path).map_err(|error| {
+        format!(
+            "Failed to open API proxy usage database {}: {error}",
+            database_path.display()
+        )
+    })?;
+    connection
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(|error| format!("Failed to configure API proxy usage timeout: {error}"))?;
+    connection
+        .pragma_update(None, "journal_mode", "WAL")
+        .map_err(|error| format!("Failed to enable API proxy usage WAL: {error}"))?;
+    connection
+        .pragma_update(None, "synchronous", "NORMAL")
+        .map_err(|error| format!("Failed to configure API proxy usage sync mode: {error}"))?;
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS api_proxy_usage_events (
+                id INTEGER PRIMARY KEY,
+                timestamp INTEGER NOT NULL,
+                key_id TEXT,
+                key_label TEXT,
+                model TEXT NOT NULL,
+                route TEXT,
+                reasoning_effort TEXT,
+                service_tier TEXT,
+                calls INTEGER NOT NULL,
+                tokens INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS api_proxy_usage_timestamp_idx
+                ON api_proxy_usage_events(timestamp);
+            CREATE TABLE IF NOT EXISTS api_proxy_usage_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+        )
+        .map_err(|error| format!("Failed to initialize API proxy usage database: {error}"))?;
+    set_private_permissions(&database_path);
+    migrate_legacy_api_proxy_usage(&mut connection, data_dir)?;
+    Ok(connection)
+}
+
+fn migrate_legacy_api_proxy_usage(
+    connection: &mut Connection,
+    data_dir: &Path,
+) -> Result<(), String> {
+    let migrated = connection
+        .query_row(
+            "SELECT value FROM api_proxy_usage_metadata WHERE key = ?1",
+            [API_PROXY_USAGE_LEGACY_MIGRATION_KEY],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| format!("Failed to inspect API proxy usage migration: {error}"))?;
+    if migrated.is_some() {
+        return Ok(());
     }
 
-    fs::read_to_string(path).is_ok_and(|raw| {
-        raw.contains("accountKey") || raw.contains("accountId") || raw.contains("accountLabel")
-    })
+    let legacy_path = data_dir.join(API_PROXY_USAGE_FILE_NAME);
+    let legacy_store = load_api_proxy_usage_store_from_path(&legacy_path)?;
+    let now = now_unix_seconds();
+    let events = legacy_store
+        .events
+        .into_iter()
+        .filter_map(|event| normalize_api_proxy_usage_event(event, now))
+        .collect::<Vec<_>>();
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format!("Failed to start API proxy usage migration: {error}"))?;
+    {
+        let mut insert = transaction
+            .prepare_cached(
+                "INSERT INTO api_proxy_usage_events (
+                    timestamp, key_id, key_label, model, route,
+                    reasoning_effort, service_tier, calls, tokens
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )
+            .map_err(|error| format!("Failed to prepare API proxy usage migration: {error}"))?;
+        for event in &events {
+            insert_api_proxy_usage_event(&mut insert, event)?;
+        }
+    }
+    transaction
+        .execute(
+            "INSERT INTO api_proxy_usage_metadata (key, value) VALUES (?1, ?2)",
+            params![
+                API_PROXY_USAGE_LEGACY_MIGRATION_KEY,
+                events.len().to_string()
+            ],
+        )
+        .map_err(|error| format!("Failed to mark API proxy usage migration: {error}"))?;
+    transaction
+        .commit()
+        .map_err(|error| format!("Failed to commit API proxy usage migration: {error}"))?;
+    Ok(())
 }
 
-fn save_api_proxy_usage_store_to_path(
-    path: &Path,
-    store: &ApiProxyUsageStore,
+fn insert_api_proxy_usage_events(
+    connection: &mut Connection,
+    events: &[ApiProxyUsageEvent],
 ) -> Result<(), String> {
-    let serialized = serde_json::to_string_pretty(store)
-        .map_err(|error| format!("序列化 API 反代统计存储失败: {error}"))?;
-    write_private_named_file_atomically(path, serialized.as_bytes(), "API 反代统计")
+    let transaction = connection
+        .transaction()
+        .map_err(|error| format!("Failed to start API proxy usage transaction: {error}"))?;
+    {
+        let mut insert = transaction
+            .prepare_cached(
+                "INSERT INTO api_proxy_usage_events (
+                    timestamp, key_id, key_label, model, route,
+                    reasoning_effort, service_tier, calls, tokens
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )
+            .map_err(|error| format!("Failed to prepare API proxy usage insert: {error}"))?;
+        for event in events {
+            insert_api_proxy_usage_event(&mut insert, event)?;
+        }
+    }
+    transaction
+        .commit()
+        .map_err(|error| format!("Failed to commit API proxy usage: {error}"))
 }
 
-fn prune_api_proxy_usage_events(events: &mut Vec<ApiProxyUsageEvent>, now: i64) -> bool {
-    let cutoff = now.saturating_sub(API_PROXY_USAGE_RETENTION_SECONDS);
-    let before = events.len();
-    events.retain(|event| {
-        event.timestamp >= cutoff
-            && !event.model.trim().is_empty()
-            && (event.calls.max(0) > 0 || event.tokens.max(0) > 0)
-    });
-    before != events.len()
+fn insert_api_proxy_usage_event(
+    insert: &mut rusqlite::CachedStatement<'_>,
+    event: &ApiProxyUsageEvent,
+) -> Result<(), String> {
+    insert
+        .execute(params![
+            event.timestamp,
+            event.key_id.as_deref(),
+            event.key_label.as_deref(),
+            event.model.as_str(),
+            event.route.as_deref(),
+            event.reasoning_effort.as_deref(),
+            event.service_tier.as_deref(),
+            event.calls,
+            event.tokens,
+        ])
+        .map(|_| ())
+        .map_err(|error| format!("Failed to insert API proxy usage: {error}"))
+}
+
+fn query_api_proxy_key_usage_logs(
+    connection: &Connection,
+    limit: usize,
+) -> Result<Vec<ApiProxyKeyUsageLogEntry>, String> {
+    let mut statement = connection
+        .prepare_cached(
+            "SELECT timestamp, key_id, key_label, model, route,
+                    reasoning_effort, service_tier, calls, tokens
+             FROM api_proxy_usage_events
+             WHERE key_id IS NOT NULL OR key_label IS NOT NULL
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?1",
+        )
+        .map_err(|error| format!("Failed to prepare API proxy usage log query: {error}"))?;
+    let entries = statement
+        .query_map([limit as i64], |row| {
+            Ok(ApiProxyKeyUsageLogEntry {
+                timestamp: row.get(0)?,
+                key_id: row.get(1)?,
+                key_label: row.get(2)?,
+                model: row.get(3)?,
+                route: row.get(4)?,
+                reasoning_effort: row.get(5)?,
+                service_tier: row.get(6)?,
+                calls: row.get::<_, i64>(7)?.max(0),
+                tokens: row.get::<_, i64>(8)?.max(0),
+            })
+        })
+        .map_err(|error| format!("Failed to query API proxy usage logs: {error}"))?;
+    entries
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read API proxy usage logs: {error}"))
+}
+
+fn query_api_proxy_usage_stats(
+    connection: &Connection,
+    now: i64,
+    range_seconds: i64,
+) -> Result<ApiProxyUsageStats, String> {
+    let start = now.saturating_sub(range_seconds);
+    let mut statement = connection
+        .prepare_cached(
+            "SELECT timestamp, key_id, key_label, model, route,
+                    reasoning_effort, service_tier, calls, tokens
+             FROM api_proxy_usage_events
+             WHERE timestamp >= ?1 AND timestamp <= ?2
+             ORDER BY id ASC",
+        )
+        .map_err(|error| format!("Failed to prepare API proxy usage stats query: {error}"))?;
+    let events = statement
+        .query_map(params![start, now], |row| {
+            Ok(ApiProxyUsageEvent {
+                timestamp: row.get(0)?,
+                key_id: row.get(1)?,
+                key_label: row.get(2)?,
+                model: row.get(3)?,
+                route: row.get(4)?,
+                reasoning_effort: row.get(5)?,
+                service_tier: row.get(6)?,
+                calls: row.get(7)?,
+                tokens: row.get(8)?,
+            })
+        })
+        .map_err(|error| format!("Failed to query API proxy usage stats: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Failed to read API proxy usage stats: {error}"))?;
+    Ok(build_api_proxy_usage_stats(&events, now, range_seconds))
 }
 
 fn build_api_proxy_usage_stats(
@@ -7508,11 +7819,11 @@ mod tests {
     use super::api_proxy_requested_models_from_payload;
     use super::api_proxy_usage_bucket_seconds;
     use super::api_proxy_usage_model_from_payload;
-    use super::api_proxy_usage_store_has_legacy_private_fields;
     use super::api_proxy_visible_models;
     use super::api_proxy_visible_models_for_key;
     use super::append_api_proxy_usage_event;
     use super::build_api_proxy_usage_stats;
+    use super::clear_api_proxy_usage_stats_with_storage;
     use super::convert_anthropic_messages_request_to_codex;
     use super::convert_completed_response_to_anthropic_message;
     use super::convert_completed_response_to_chat_completion;
@@ -7527,6 +7838,7 @@ mod tests {
     use super::extract_completed_response_from_sse;
     use super::find_http_header_end;
     use super::get_api_proxy_key_usage_logs_with_storage;
+    use super::get_api_proxy_usage_stats_with_storage;
     use super::host_matches_no_proxy;
     use super::is_responses_terminal_event;
     use super::list_api_proxy_keys_with_storage;
@@ -7536,7 +7848,6 @@ mod tests {
     use super::order_proxy_candidates_for_request;
     use super::parse_http_proxy_config;
     use super::parse_proxy_request_body_limit_mib;
-    use super::prune_api_proxy_usage_events;
     use super::regenerate_api_proxy_key_with_runtime;
     use super::request_session_affinity_key;
     use super::resolve_proxy_request_body_limit_bytes_from_mib_value;
@@ -7559,8 +7870,10 @@ mod tests {
     use super::ProxyLoadBalanceConfig;
     use super::ProxyStorageContext;
     use super::SseEvent;
+    use super::API_PROXY_USAGE_DATABASE_FILE_NAME;
+    use super::API_PROXY_USAGE_FILE_NAME;
     use super::API_PROXY_USAGE_RANGE_1H_SECONDS;
-    use super::API_PROXY_USAGE_RETENTION_SECONDS;
+    use super::API_PROXY_USAGE_RANGE_30D_SECONDS;
     use super::DEFAULT_PROXY_REQUEST_BODY_LIMIT_BYTES;
     use crate::models::ApiProxyKey;
     use crate::models::ApiProxyLoadBalanceMode;
@@ -7698,6 +8011,7 @@ mod tests {
                 data_dir: data_dir.clone(),
                 store_lock: Arc::new(tokio::sync::Mutex::new(())),
                 auth_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+                usage_writer: Arc::new(tokio::sync::Mutex::new(None)),
                 sync_active_auth_on_refresh: false,
             },
             data_dir,
@@ -8044,6 +8358,7 @@ mod tests {
         assert_eq!(logs[0].calls, 1);
         assert_eq!(logs[0].tokens, 99);
 
+        drop(storage);
         std::fs::remove_dir_all(data_dir).expect("temporary proxy storage should be removable");
     }
 
@@ -8120,48 +8435,89 @@ mod tests {
         assert!(error.contains("high"));
     }
 
-    #[test]
-    fn api_proxy_usage_pruning_removes_events_older_than_retention() {
-        let now = 10_000_000;
-        let cutoff = now - API_PROXY_USAGE_RETENTION_SECONDS;
-        let mut events = vec![
-            usage_event(cutoff - 1, "gpt-5.4", 1, 0),
-            usage_event(cutoff, "gpt-5.4", 1, 0),
-            usage_event(now, "gpt-5.5", 0, 20),
-        ];
+    #[tokio::test]
+    async fn api_proxy_usage_migrates_once_keeps_history_and_only_clears_manually() {
+        let (storage, data_dir) = temp_proxy_storage_context("api-usage-migration");
+        let now = now_unix_seconds();
+        let old_timestamp = now - 60 * 24 * 60 * 60;
+        let legacy = serde_json::to_string_pretty(&json!({
+            "version": 1,
+            "updatedAt": now,
+            "events": [
+                {
+                    "timestamp": old_timestamp,
+                    "keyId": "key-old",
+                    "keyLabel": "Old tenant",
+                    "accountKey": "must-not-migrate",
+                    "model": "gpt-5.4",
+                    "route": "/v1/responses",
+                    "calls": 1,
+                    "tokens": 0
+                },
+                {
+                    "timestamp": now,
+                    "keyId": "key-new",
+                    "keyLabel": "New tenant",
+                    "model": "gpt-5.5",
+                    "route": "/v1/responses",
+                    "calls": 1,
+                    "tokens": 12
+                }
+            ]
+        }))
+        .expect("legacy usage should serialize");
+        let legacy_path = data_dir.join(API_PROXY_USAGE_FILE_NAME);
+        std::fs::write(&legacy_path, &legacy).expect("legacy usage should be writable");
 
-        let changed = prune_api_proxy_usage_events(&mut events, now);
-
-        assert!(changed);
-        assert_eq!(events.len(), 2);
-        assert!(events.iter().all(|event| event.timestamp >= cutoff));
-    }
-
-    #[test]
-    fn api_proxy_usage_store_detects_legacy_private_fields() {
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "codex-tools-usage-legacy-{}-{}.json",
-            std::process::id(),
-            now_unix_seconds()
-        ));
-
-        std::fs::write(
-            &path,
-            r#"{"version":1,"events":[{"accountKey":"a","accountId":"b","accountLabel":"c","route":"/v1/responses"}]}"#,
+        let stats = get_api_proxy_usage_stats_with_storage(
+            &storage,
+            Some(API_PROXY_USAGE_RANGE_30D_SECONDS),
         )
-        .expect("write legacy usage store");
+        .await
+        .expect("migrated usage should be queryable");
+        assert_eq!(
+            stats
+                .series
+                .iter()
+                .map(|series| series.total_calls)
+                .sum::<i64>(),
+            1
+        );
 
-        assert!(api_proxy_usage_store_has_legacy_private_fields(&path));
+        let logs = get_api_proxy_key_usage_logs_with_storage(&storage, Some(10))
+            .await
+            .expect("migrated key logs should be queryable");
+        assert_eq!(logs.len(), 2, "old usage is retained until manual clear");
+        assert_eq!(
+            std::fs::read_to_string(&legacy_path).expect("legacy file remains readable"),
+            legacy,
+            "migration must not overwrite the legacy JSON"
+        );
 
-        std::fs::write(
-            &path,
-            r#"{"version":1,"events":[{"timestamp":1,"model":"gpt-5.4","calls":1,"tokens":0}]}"#,
-        )
-        .expect("write sanitized usage store");
+        let database_path = data_dir.join(API_PROXY_USAGE_DATABASE_FILE_NAME);
+        let connection =
+            rusqlite::Connection::open(&database_path).expect("usage database should be readable");
+        let count = || {
+            connection
+                .query_row("SELECT COUNT(*) FROM api_proxy_usage_events", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("usage rows should be countable")
+        };
+        assert_eq!(count(), 2);
+        get_api_proxy_usage_stats_with_storage(&storage, None)
+            .await
+            .expect("reopening usage must not duplicate migration");
+        assert_eq!(count(), 2);
 
-        assert!(!api_proxy_usage_store_has_legacy_private_fields(&path));
-        let _ = std::fs::remove_file(path);
+        clear_api_proxy_usage_stats_with_storage(&storage)
+            .await
+            .expect("manual clear should succeed");
+        assert_eq!(count(), 0);
+
+        drop(connection);
+        drop(storage);
+        std::fs::remove_dir_all(data_dir).expect("temporary proxy storage should be removable");
     }
 
     #[test]

--- a/src-tauri/src/proxy_service.rs
+++ b/src-tauri/src/proxy_service.rs
@@ -5635,6 +5635,9 @@ fn open_api_proxy_usage_database(data_dir: &Path) -> Result<Connection, String> 
         .pragma_update(None, "synchronous", "NORMAL")
         .map_err(|error| format!("Failed to configure API proxy usage sync mode: {error}"))?;
     connection
+        .pragma_update(None, "temp_store", "MEMORY")
+        .map_err(|error| format!("Failed to keep API proxy temporary data in memory: {error}"))?;
+    connection
         .execute_batch(
             "CREATE TABLE IF NOT EXISTS api_proxy_usage_events (
                 id INTEGER PRIMARY KEY,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 use crate::auth::PendingOauthLogin;
 use crate::models::ApiProxyKey;
 use crate::models::CloudflaredTunnelMode;
+use crate::proxy_service::ApiProxyUsageWriter;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ApiProxySessionAffinity {
@@ -69,6 +70,7 @@ pub(crate) struct AppState {
     pub(crate) pending_oauth_login: Mutex<Option<PendingOauthLogin>>,
     pub(crate) oauth_listener: Mutex<Option<OauthCallbackListenerHandle>>,
     pub(crate) api_proxy: Mutex<Option<ApiProxyRuntimeHandle>>,
+    pub(crate) api_proxy_usage_writer: Arc<Mutex<Option<ApiProxyUsageWriter>>>,
     pub(crate) cloudflared: Mutex<Option<CloudflaredRuntimeHandle>>,
 }
 
@@ -80,6 +82,7 @@ impl Default for AppState {
             pending_oauth_login: Mutex::new(None),
             oauth_listener: Mutex::new(None),
             api_proxy: Mutex::new(None),
+            api_proxy_usage_writer: Arc::new(Mutex::new(None)),
             cloudflared: Mutex::new(None),
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,7 @@ function App() {
     onSmartSwitch,
     onUpdateRemoteServers,
     smartSwitching,
-  } = useCodexController();
+  } = useCodexController(activeTab);
 
   useEffect(() => {
     const isMac =
@@ -237,11 +237,10 @@ function App() {
     }
     void refreshUsage(false);
     void refreshTokenUsage(false);
-    void loadCostAnalytics(true);
   };
 
   return (
-    <div className="shell">
+    <div className={`shell${mainWindowVisible ? "" : " isUiInactive"}`}>
       <div className="ambient" />
       <main className="panel">
         <AppTopBar

--- a/src/hooks/useCodexController.ts
+++ b/src/hooks/useCodexController.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
 import { PROJECT_LATEST_RELEASE_URL } from "../constants/externalLinks";
@@ -51,11 +52,11 @@ import {
 } from "../utils/changelog";
 
 const REFRESH_MS = 30_000;
-const COST_ANALYTICS_REFRESH_MS = 60_000;
+const COST_ANALYTICS_STALE_MS = 30 * 60 * 1000;
 const EDITOR_SCAN_MS = 60_000;
 const UPDATE_CHECK_MS = 60 * 60 * 1000;
 const API_PROXY_POLL_MS = 4_000;
-const API_PROXY_USAGE_POLL_MS = 2_000;
+const API_PROXY_USAGE_POLL_MS = 15_000;
 const CLOUDFLARED_POLL_MS = 3_000;
 const MAIN_WINDOW_VISIBILITY_CHANGED_EVENT = "main-window-visibility-changed";
 const DEFAULT_API_PROXY_USAGE_RANGE: ApiProxyUsageRange = "24h";
@@ -192,14 +193,22 @@ function buildRemoteProxyFallback(
   };
 }
 
-export function useCodexController() {
+export function useCodexController(
+  activeTab: "accounts" | "analytics" | "proxy" | "settings",
+) {
   const { copy, locale } = useI18n();
   const [accounts, setAccounts] = useState<AccountSummary[]>([]);
   const [tokenUsage, setTokenUsage] = useState<CodexTokenUsageSnapshot | null>(
     null,
   );
   const [tokenUsageError, setTokenUsageError] = useState<string | null>(null);
-  const [mainWindowVisible, setMainWindowVisible] = useState(true);
+  const [mainWindowShown, setMainWindowShown] = useState(true);
+  const [mainWindowMinimized, setMainWindowMinimized] = useState(false);
+  const [documentVisible, setDocumentVisible] = useState(
+    () => typeof document === "undefined" || document.visibilityState !== "hidden",
+  );
+  const mainWindowVisible =
+    mainWindowShown && !mainWindowMinimized && documentVisible;
   const [costAnalytics, setCostAnalytics] =
     useState<CodexCostAnalyticsSnapshot | null>(null);
   const [costAnalyticsError, setCostAnalyticsError] = useState<string | null>(
@@ -303,7 +312,6 @@ export function useCodexController() {
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
   const [notice, setNotice] = useState<Notice | null>(null);
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
-  const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [savingSettings, setSavingSettings] = useState(false);
   const [installedEditorApps, setInstalledEditorApps] = useState<
     InstalledEditorApp[]
@@ -476,13 +484,9 @@ export function useCodexController() {
   );
 
   const loadSettings = useCallback(async () => {
-    try {
-      const data = await invoke<AppSettings>("get_app_settings");
-      settingsRef.current = data;
-      setSettings(data);
-    } finally {
-      setSettingsLoaded(true);
-    }
+    const data = await invoke<AppSettings>("get_app_settings");
+    settingsRef.current = data;
+    setSettings(data);
   }, []);
 
   const loadInstalledEditorApps = useCallback(async () => {
@@ -1095,7 +1099,7 @@ export function useCodexController() {
 
     void listen<boolean>(MAIN_WINDOW_VISIBILITY_CHANGED_EVENT, (event) => {
       if (!disposed) {
-        setMainWindowVisible(event.payload);
+        setMainWindowShown(event.payload);
       }
     })
       .then((fn) => {
@@ -1111,6 +1115,52 @@ export function useCodexController() {
       disposed = true;
       if (unlisten) {
         void unlisten();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlistenResized: UnlistenFn | null = null;
+    const currentWindow = getCurrentWindow();
+
+    const syncMinimized = async () => {
+      try {
+        const minimized = await currentWindow.isMinimized();
+        if (!disposed) {
+          setMainWindowMinimized(minimized);
+        }
+      } catch {
+        // Browser-only previews do not provide a native window.
+      }
+    };
+    const syncDocumentVisibility = () => {
+      setDocumentVisible(document.visibilityState !== "hidden");
+    };
+
+    document.addEventListener("visibilitychange", syncDocumentVisibility);
+    void currentWindow
+      .onResized(() => {
+        void syncMinimized();
+      })
+      .then((unlisten) => {
+        if (disposed) {
+          void unlisten();
+          return;
+        }
+        unlistenResized = unlisten;
+      })
+      .catch(() => {});
+    void syncMinimized();
+
+    return () => {
+      disposed = true;
+      document.removeEventListener(
+        "visibilitychange",
+        syncDocumentVisibility,
+      );
+      if (unlistenResized) {
+        void unlistenResized();
       }
     };
   }, []);
@@ -1158,16 +1208,13 @@ export function useCodexController() {
         loadOpencodeDesktopAppInstalled(),
         loadApiProxySupportedModels(),
         loadApiProxyKeys(),
-        loadApiProxyKeyLogs(),
         loadApiProxyStatus(),
-        loadApiProxyUsageStats(DEFAULT_API_PROXY_USAGE_RANGE),
         loadCloudflaredStatus(),
         // A clean installation has no cached usage yet. Allow this one silent
         // startup refresh to renew stale auth tokens, while periodic refreshes
         // remain lightweight and do not rotate credentials unnecessarily.
         refreshUsage(true, true, true),
         refreshTokenUsage(true),
-        loadCostAnalytics(true),
         settingsTask.then(() => checkForAppUpdate(true)),
       ]);
     };
@@ -1180,13 +1227,10 @@ export function useCodexController() {
   }, [
     checkForAppUpdate,
     loadAccounts,
-    loadApiProxyKeyLogs,
     loadApiProxyKeys,
     loadApiProxySupportedModels,
     loadApiProxyStatus,
-    loadApiProxyUsageStats,
     loadCloudflaredStatus,
-    loadCostAnalytics,
     loadInstalledEditorApps,
     loadOpencodeDesktopAppInstalled,
     loadSettings,
@@ -1227,17 +1271,33 @@ export function useCodexController() {
   ]);
 
   useEffect(() => {
-    if (!settingsLoaded) {
+    if (!mainWindowVisible || activeTab !== "analytics") {
       return;
     }
 
-    void refreshCostAnalytics(true);
-    const timer = window.setInterval(() => {
-      void refreshCostAnalytics(true);
-    }, COST_ANALYTICS_REFRESH_MS);
+    let cancelled = false;
+    void (async () => {
+      const cached = await loadCostAnalytics(true);
+      if (cancelled) {
+        return;
+      }
+      const updatedAtMs = (cached?.updatedAt ?? 0) * 1000;
+      const stale =
+        !cached || Date.now() >= updatedAtMs + COST_ANALYTICS_STALE_MS;
+      if (stale) {
+        await refreshCostAnalytics(Boolean(cached));
+      }
+    })();
 
-    return () => window.clearInterval(timer);
-  }, [refreshCostAnalytics, settingsLoaded]);
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeTab,
+    loadCostAnalytics,
+    mainWindowVisible,
+    refreshCostAnalytics,
+  ]);
 
   useEffect(() => {
     if (loading) {
@@ -1330,10 +1390,14 @@ export function useCodexController() {
   }, [loading, settings.remoteServers]);
 
   useEffect(() => {
-    if (!mainWindowVisible || !apiProxyStatus.running) {
+    if (!mainWindowVisible || activeTab !== "proxy") {
       return;
     }
 
+    void loadApiProxyStatus();
+    if (!apiProxyStatus.running) {
+      return;
+    }
     const timer = setInterval(() => {
       void loadApiProxyStatus();
     }, API_PROXY_POLL_MS);
@@ -1341,19 +1405,27 @@ export function useCodexController() {
     return () => {
       clearInterval(timer);
     };
-  }, [apiProxyStatus.running, loadApiProxyStatus, mainWindowVisible]);
+  }, [
+    activeTab,
+    apiProxyStatus.running,
+    loadApiProxyStatus,
+    mainWindowVisible,
+  ]);
 
   useEffect(() => {
     if (
       !mainWindowVisible ||
-      !apiProxyStatus.running ||
-      apiProxyUsageLoading ||
-      apiProxyUsageClearing ||
-      apiProxyUsagePollInFlightRef.current
+      activeTab !== "proxy" ||
+      apiProxyUsageClearing
     ) {
       return;
     }
 
+    void loadApiProxyUsageStats(apiProxyUsageRange);
+    void loadApiProxyKeyLogs();
+    if (!apiProxyStatus.running) {
+      return;
+    }
     const timer = setInterval(() => {
       void loadApiProxyUsageStats(apiProxyUsageRange, { silent: true });
       void loadApiProxyKeyLogs({ silent: true });
@@ -1363,9 +1435,9 @@ export function useCodexController() {
       clearInterval(timer);
     };
   }, [
+    activeTab,
     apiProxyStatus.running,
     apiProxyUsageClearing,
-    apiProxyUsageLoading,
     apiProxyUsageRange,
     loadApiProxyKeyLogs,
     loadApiProxyUsageStats,
@@ -1373,10 +1445,14 @@ export function useCodexController() {
   ]);
 
   useEffect(() => {
-    if (!mainWindowVisible || !cloudflaredStatus.running) {
+    if (!mainWindowVisible || activeTab !== "proxy") {
       return;
     }
 
+    void loadCloudflaredStatus();
+    if (!cloudflaredStatus.running) {
+      return;
+    }
     const timer = setInterval(() => {
       void loadCloudflaredStatus();
     }, CLOUDFLARED_POLL_MS);
@@ -1384,7 +1460,12 @@ export function useCodexController() {
     return () => {
       clearInterval(timer);
     };
-  }, [cloudflaredStatus.running, loadCloudflaredStatus, mainWindowVisible]);
+  }, [
+    activeTab,
+    cloudflaredStatus.running,
+    loadCloudflaredStatus,
+    mainWindowVisible,
+  ]);
 
   useEffect(() => {
     let disposed = false;
@@ -1751,7 +1832,6 @@ export function useCodexController() {
           port: port ?? null,
         });
         setApiProxyStatus(localizeApiProxyStatus(status));
-        void loadApiProxyUsageStats(apiProxyUsageRange);
         const target = status.port
           ? `127.0.0.1:${status.port}`
           : copy.notices.proxyLocalTargetFallback;
@@ -1767,9 +1847,7 @@ export function useCodexController() {
     },
     [
       apiProxyStatus.running,
-      apiProxyUsageRange,
       copy.notices,
-      loadApiProxyUsageStats,
       localizeApiProxyStatus,
       localizeError,
       startingApiProxy,
@@ -1988,9 +2066,8 @@ export function useCodexController() {
         return;
       }
       setApiProxyUsageRange(range);
-      void loadApiProxyUsageStats(range);
     },
-    [apiProxyUsageRange, loadApiProxyUsageStats],
+    [apiProxyUsageRange],
   );
 
   const onSelectApiProxyUsageMetric = useCallback(
@@ -2011,8 +2088,6 @@ export function useCodexController() {
     setApiProxyUsageClearing(true);
     try {
       await invoke("clear_api_proxy_usage_stats");
-      await loadApiProxyUsageStats(apiProxyUsageRange);
-      await loadApiProxyKeyLogs({ silent: true });
       setNotice({ type: "ok", message: copy.notices.apiProxyUsageCleared });
     } catch (error) {
       setNotice({
@@ -2026,10 +2101,7 @@ export function useCodexController() {
     }
   }, [
     apiProxyUsageClearing,
-    apiProxyUsageRange,
     copy.notices,
-    loadApiProxyKeyLogs,
-    loadApiProxyUsageStats,
     localizeError,
   ]);
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -16,6 +16,15 @@
   transition: background 180ms ease, color 180ms ease;
 }
 
+.shell.isUiInactive .proxyStatusDot.isRunning,
+.shell.isUiInactive .proxyUsageHoverMarkerHalo,
+.shell.isUiInactive .proxyUsageStateOrb.isLoading,
+.shell.isUiInactive .remoteDependencyInstallFill,
+.shell.isUiInactive .iconGlyph.isSpinning,
+.shell.isUiInactive .usageFreshnessBadge.tone-refreshing .usageFreshnessDot {
+  animation-play-state: paused;
+}
+
 .ambient {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
# English

## Problems found

### 1. Usage persistence scaled with the entire history file

Proxy usage was stored as one pretty-printed JSON document. Recording an event required loading the existing history, appending one item, serializing the complete document, replacing the file, and synchronizing it to disk.

A normal API call commonly produces two usage events, so the full history could be rewritten twice for one call. With the 143,000-event fixture used during profiling, the JSON file was 41.015 MiB and one API call caused 82.03 MiB of logical reads plus 82.03 MiB of logical writes. The request path also waited for this persistence work.

Usage reads were not read-only in every case: retention and legacy-field cleanup could rewrite the store during a statistics query. The fixed retention policy could also remove history without an explicit administrator action.

### 2. Statistics refreshes repeatedly scanned the full history

The frontend requested usage statistics and key logs every two seconds. Those two backend operations repeatedly loaded and parsed the complete JSON history instead of selecting only the requested time range or the latest log rows.

At the profiled history size, one combined statistics and key-log refresh generated 164.06 MiB of logical reads and took 7.22 seconds in the debug benchmark. Because this polling continued outside the Proxy page, the work could run while the user was viewing Accounts, Analytics, or Settings.

### 3. Inactive UI work continued unnecessarily

Proxy status, Cloudflared status, usage statistics, and key logs continued polling whenever the main window was considered visible, even when the Proxy page was not active. A normally minimized window could still be treated as visible.

Several infinite CSS animations also continued compositing while the window was minimized or hidden. This did not affect request forwarding, but it kept WebView CPU/GPU activity alive without providing visible feedback.

### 4. Analytics refreshed even when it was not being viewed

Analytics performed a background refresh every minute after startup. Each refresh recursively enumerated the session JSONL tree, read file metadata to identify changes, and rewrote the cache even when the Analytics page had never been opened. The existing in-memory incremental cache already avoided reparsing unchanged session files, but discovery, fingerprint checks, and cache writes still ran every minute.

## What changed

### 1. Append usage through a dedicated SQLite writer

- Replace whole-file JSON rewrites with a SQLite database using WAL mode and `synchronous=NORMAL`.
- Send usage events to a dedicated writer thread so request forwarding only enqueues the event.
- Batch up to 256 queued events into one transaction.
- Serialize append, query, and manual-clear commands through the same writer connection.
- Index event timestamps and query only the selected statistics range.
- Fetch key logs directly in newest-first order with a SQL `LIMIT`.
- Keep temporary sort data in memory with `temp_store=MEMORY`, preserving result order without temporary disk files.
- Keep persistence failures isolated from forwarding. Only database failure paths emit warnings; request bodies and API keys are not logged.

The existing `api-proxy-usage.json` is imported once when the database is first opened. Migration does not edit or delete the legacy file and is marked transactionally so reopening the database cannot duplicate events. History is retained until the existing manual clear action is used; this change does not introduce automatic cleanup.

### 2. Scope frontend work to the page and window state

- Poll usage statistics and key logs every 15 seconds instead of every two seconds.
- Run usage, proxy-status, key-log, and Cloudflared polling only while the Proxy page is active and the window is actually visible.
- Treat native minimization, the Tauri show/hide state, and document visibility as inactive UI states.
- Stop the related timers while inactive and refresh immediately when the relevant page becomes active again.
- Pause existing infinite CSS animations only while the UI is inactive; visible-state appearance and animation behavior are unchanged.

The proxy runtime is independent of these UI timers. Local API requests continue to be served while the app is on another page, minimized, or hidden to the tray.

### 3. Lazy-load Analytics

- Remove the unconditional startup scan and one-minute background refresh.
- Load the existing Analytics cache when the page is opened.
- Rescan session files only when the cache is missing or older than 30 minutes.
- Keep the existing manual refresh action for an immediate administrator-requested scan.

## Results

### Benchmark

The benchmark used 143,000 synthetic usage events and a 41.015 MiB pretty-printed legacy JSON file. Measurements were taken on Windows with `GetProcessIoCounters`, a warm filesystem cache, and debug benchmark binaries.

The workload was fitted to the large local history observed during profiling and is intended for before/after comparison in the same environment, not as a portable performance guarantee.

Implementation note: the SQLite statistics query intentionally uses `ORDER BY id` to preserve stable event order. During local profiling, SQLite's default disk-backed temporary storage produced 14.73 MiB of temporary logical writes per large query; `temp_store=MEMORY` kept this implementation-specific sort in memory.

| Scenario | Before | After |
| --- | ---: | ---: |
| Persist one API call / two usage events | 82.03 MiB read + 82.03 MiB write; 10.57 s | about 8 B read + 490 B write; about 5.9 microseconds to enqueue |
| Refresh statistics and key logs | 164.06 MiB read; 7.22 s | statistics: 17.73 MiB read, 0 temporary write, 1.20-1.48 s; key logs: about 1-2 ms and 0 measured I/O |
| Continuous statistics polling | every 2 s on every page; about 288.4 GiB logical read/hour | every 15 s only on the visible Proxy page; about 4.15 GiB/hour; no polling off-page, minimized, or hidden |
| Large SQLite sorted statistics query | 32.46 MiB read + 14.73 MiB temporary write with disk-backed temp storage | 17.73 MiB read + 0 temporary write with memory-backed temp storage |

Normalized steady-state logical write traffic per API call fell by approximately 175,430x (99.99943%). Moving temporary sort storage to memory used roughly 15 MiB of transient working memory for the large fixture. Twenty repeated 143,000-event queries returned to the same reported SQLite memory usage after every query (2,178,448 bytes; spread 0), with no per-query accumulation observed.

These figures are process logical-I/O measurements, not physical NAND writes, SSD endurance estimates, release-build latency, or power measurements. They are intended to compare the old and new code paths under the same controlled workload.

### Behavior and compatibility

- Request forwarding behavior and API responses are unchanged.
- Existing usage history is migrated once and the original JSON remains untouched.
- Usage history is cleared only by the explicit manual action.
- The local proxy remains available while the window is visible, minimized, or hidden to the tray; `/v1/models` was exercised in all three states on Windows.
- The official desktop release matrix currently covers Windows and macOS Intel/Apple Silicon. The new runtime code uses standard Rust synchronization, bundled SQLite, Tauri window APIs, and CSS without adding OS-specific branches.
- Windows desktop and standalone `proxyd` release builds passed.
- A locked Linux x86_64 musl standalone `proxyd` release build passed in an isolated Alpine container.
- macOS was source-reviewed but was not locally compiled on the Windows test host.

### Validation

- `npm run lint`
- `npm run test:usage-errors`: 8/8 passed
- Proxy-focused Rust tests: 90/90 passed
- `cargo fmt --check`
- `git diff --check`
- `npm run tauri -- build --no-bundle`
- Windows standalone `proxyd` release build
- Linux x86_64 musl standalone `proxyd` release build with `--locked`

---

# 中文

## 发现的问题

### 1. 统计写入开销随整个历史文件增长

代理统计原本保存在一个格式化 JSON 文档中。每记录一条事件，都需要读取已有历史、追加新事件、重新序列化整个文档、替换文件并同步到磁盘。

一次普通 API 调用通常会产生两条统计事件，因此一次调用可能完整重写两遍历史文件。在性能分析使用的 14.3 万条事件数据中，JSON 文件大小为 41.015 MiB；一次 API 调用会产生 82.03 MiB 逻辑读取和 82.03 MiB 逻辑写入，并且请求路径需要等待持久化操作完成。

统计查询也不一定是纯读取：执行保留期清理或旧字段清理时，查询过程可能再次重写统计文件。固定保留策略还可能在没有管理员明确操作的情况下删除历史数据。

### 2. 统计刷新反复扫描完整历史

前端每两秒请求一次统计数据和 key 日志。后端的两个操作都会反复加载并解析完整 JSON 历史，而不是只读取选定时间范围或最新的日志记录。

在本次测试的数据规模下，一轮统计和 key 日志刷新会产生 164.06 MiB 逻辑读取，调试基准耗时 7.22 秒。由于轮询不受当前页面限制，即使用户正在查看 Accounts、Analytics 或 Settings，这些工作仍可能持续运行。

### 3. 界面非活跃时仍持续执行后台工作

只要主窗口被认为可见，代理状态、Cloudflared 状态、统计数据和 key 日志就会继续轮询，即使当前并不在 Proxy 页面。普通最小化状态也可能仍被当作可见窗口。

多项无限 CSS 动画在窗口最小化或隐藏后仍继续合成。它们不会影响请求转发，但会在没有任何可见反馈的情况下持续占用 WebView CPU/GPU。

### 4. 未查看 Analytics 时仍定期刷新

应用启动后，Analytics 原本每分钟执行一次后台刷新。每轮刷新都会递归枚举 session JSONL 目录、读取文件 metadata 以识别变化，并在用户从未打开 Analytics 页面时仍重写缓存。现有内存增量缓存会复用未变化文件的解析结果，但文件发现、指纹检查和缓存写入仍每分钟执行。

## 解决方案

### 1. 使用独立 SQLite 写入线程追加统计

- 使用 WAL 模式和 `synchronous=NORMAL` 的 SQLite 数据库替代整文件 JSON 重写。
- 将统计事件发送到独立写入线程，请求转发路径只负责入队。
- 每个事务最多批量写入 256 条已排队事件。
- 追加、查询和手动清空命令通过同一个写入连接串行处理。
- 为时间戳建立索引，只查询用户选择的统计时间范围。
- 使用 SQL 的倒序和 `LIMIT` 直接读取最新 key 日志。
- 设置 `temp_store=MEMORY`，在保持结果顺序不变的情况下避免排序临时文件写盘。
- 统计持久化失败与请求转发隔离。只有数据库异常路径会输出 warning，不记录请求正文或 API key。

数据库首次打开时会迁移现有的 `api-proxy-usage.json`。迁移只执行一次，不修改或删除旧 JSON，并通过事务记录迁移状态，避免重新打开数据库时重复导入。统计历史会一直保留到管理员使用现有的手动清空操作；本次修改不增加自动清理。

### 2. 根据页面和窗口状态限制前端后台工作

- 将统计和 key 日志轮询间隔从两秒调整为 15 秒。
- 仅在 Proxy 页面处于活动状态且窗口真正可见时，执行统计、代理状态、key 日志和 Cloudflared 轮询。
- 同时使用原生最小化状态、Tauri 显示/隐藏状态和 document visibility 判断界面是否活跃。
- 界面非活跃时停止相关计时器，在重新进入对应页面时立即刷新一次。
- 只在界面非活跃时暂停已有无限 CSS 动画；窗口可见时的外观和动画效果不变。

代理运行时不依赖这些 UI 计时器。切换到其他页面、最小化窗口或隐藏到托盘后，本地 API 仍会继续提供服务。

### 3. 懒加载 Analytics

- 移除启动时的无条件扫描和每分钟后台刷新。
- 进入 Analytics 页面时先读取已有缓存。
- 仅在缓存不存在或时间戳超过 30 分钟时重新扫描 session 文件。
- 保留现有手动刷新操作，管理员仍可立即触发扫描。

## 最终结果

### 性能基准

基准使用 14.3 万条合成统计事件和一个 41.015 MiB 的格式化旧版 JSON 文件。测试在 Windows 上通过 `GetProcessIoCounters` 测量，使用暖文件系统缓存和调试基准程序。

该负载根据本机 profiling 中观察到的大历史文件场景拟合，用于同一环境下修改前后的代码路径对比，不作为跨机器性能保证。

实现说明：SQLite 统计查询有意使用 `ORDER BY id` 保持稳定事件顺序。本地 profiling 发现 SQLite 默认的磁盘临时存储会让大型查询产生 14.73 MiB 临时逻辑写入；`temp_store=MEMORY` 会将这项由本次实现引入的排序保留在内存中。

| 场景 | 修改前 | 修改后 |
| --- | ---: | ---: |
| 保存一次 API 调用产生的两条统计事件 | 82.03 MiB 读取 + 82.03 MiB 写入；10.57 秒 | 约 8 B 读取 + 490 B 写入；入队约 5.9 微秒 |
| 刷新统计和 key 日志 | 164.06 MiB 读取；7.22 秒 | 统计：17.73 MiB 读取、0 临时写入、1.20-1.48 秒；key 日志：约 1-2 毫秒、未测得 I/O |
| 持续统计轮询 | 所有页面每两秒执行；约 288.4 GiB 逻辑读取/小时 | 仅可见 Proxy 页面每 15 秒执行；约 4.15 GiB/小时；离开页面、最小化或隐藏后为零轮询 |
| SQLite 大型排序统计查询 | 使用磁盘临时存储时读取 32.46 MiB、临时写入 14.73 MiB | 使用内存临时存储后读取 17.73 MiB、临时写入为零 |

按单次 API 调用归一化后，稳态逻辑写入量约降低 175,430 倍（99.99943%）。将排序临时存储移到内存后，大型测试数据会使用约 15 MiB 瞬时工作内存。连续执行 20 次 14.3 万事件查询后，每次查询结束时 SQLite 报告的内存占用都回到相同的 2,178,448 字节（波动为零），未观察到逐次累积。

这些数字是进程逻辑 I/O，不代表物理 NAND 写入量、SSD 寿命、release 构建延迟或实际功耗。它们用于在相同受控负载下比较修改前后的代码路径。

### 行为与兼容性

- 请求转发行为和 API 响应保持不变。
- 现有统计历史只迁移一次，原始 JSON 保持不变。
- 统计历史仅通过明确的手动操作清空。
- 窗口可见、最小化或隐藏到托盘时，本地代理都保持可用；Windows 上已在三种状态分别验证 `/v1/models`。
- 官方桌面发布矩阵目前覆盖 Windows、Intel macOS 和 Apple Silicon macOS。新增运行时代码使用标准 Rust 同步原语、内置 SQLite、Tauri 窗口 API 和 CSS，没有增加操作系统专用分支。
- Windows 桌面端和独立 `proxyd` release 构建通过。
- 在隔离 Alpine 容器中，Linux x86_64 musl 独立 `proxyd` 使用锁定依赖完成 release 构建。
- macOS 已完成源码兼容性审查，但本次 Windows 测试主机无法执行本地 macOS 编译。

### 验证项目

- `npm run lint`
- `npm run test:usage-errors`：8/8 通过
- Proxy 定向 Rust 测试：90/90 通过
- `cargo fmt --check`
- `git diff --check`
- `npm run tauri -- build --no-bundle`
- Windows 独立 `proxyd` release 构建
- Linux x86_64 musl 独立 `proxyd` 使用 `--locked` 的 release 构建

Closes #177
