### PR TITLE
EN: Restore broken star history chart in README / ZH: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,11 @@ docs/                    Extra documentation
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=170-carry/codex-tools&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#170-carry/codex-tools&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=170-carry/codex-tools&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=170-carry/codex-tools&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=170-carry/codex-tools&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=170-carry/codex-tools&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=170-carry/codex-tools&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=170-carry/codex-tools&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken, and since it reflects the popularity of the project, we think it should be fixed as soon as possible. This change restores the chart by pointing it to a working star history instance and updates the surrounding link and image URLs to match.

README 中的 Star History 图表当前已失效，而它反映了项目的受欢迎程度，我们认为应尽快修复。本次改动将图表指向可用的 Star History 服务，并同步更新对应的链接与图片地址。