### PR TITLE
fix(proxy): 修复 Anthropic /v1/messages max_tokens 400 与流式 tool_use 重复块

### DIFF
--- a/docs/api-proxy.md
+++ b/docs/api-proxy.md
@@ -230,7 +230,7 @@ Tauri 命令入口在：
 - `model`
 - `system`
 - `messages`
-- `max_tokens`
+- `max_tokens`（接受但不会转发：Codex 上游会拒绝 `max_output_tokens`，而 Anthropic 规范要求客户端必填该字段）
 - `stream`
 - `temperature`
 - `top_p`

--- a/src-tauri/src/proxy_service.rs
+++ b/src-tauri/src/proxy_service.rs
@@ -641,6 +641,7 @@ struct AnthropicStreamState {
     open_tool_index: Option<i64>,
     saw_tool_use: bool,
     has_received_tool_arguments_delta: bool,
+    has_tool_call_announced: bool,
 }
 
 impl Default for AnthropicStreamState {
@@ -654,6 +655,7 @@ impl Default for AnthropicStreamState {
             open_tool_index: None,
             saw_tool_use: false,
             has_received_tool_arguments_delta: false,
+            has_tool_call_announced: false,
         }
     }
 }
@@ -3274,15 +3276,10 @@ fn convert_anthropic_messages_request_to_codex(request: &Value) -> Result<(Value
         }),
     );
 
-    if let Some(max_tokens) = request_object
-        .get("max_tokens")
-        .and_then(integer_field_value)
-    {
-        root.insert(
-            "max_output_tokens".to_string(),
-            Value::Number(serde_json::Number::from(max_tokens)),
-        );
-    }
+    // max_tokens is accepted but intentionally not forwarded: the Codex
+    // upstream rejects requests carrying max_output_tokens with
+    // "Unsupported parameter: max_output_tokens", and Anthropic clients
+    // (e.g. Claude Code) are required to always send max_tokens.
     copy_anthropic_passthrough_field(request_object, &mut root, "temperature", "temperature");
     copy_anthropic_passthrough_field(request_object, &mut root, "top_p", "top_p");
     root.insert(
@@ -8777,6 +8774,7 @@ fn translate_sse_event_to_anthropic_event(
                 return Vec::new();
             }
             let mut events = stop_anthropic_text_block(state);
+            state.has_tool_call_announced = true;
             events.extend(start_anthropic_tool_block(state, item, None));
             events
         }
@@ -8822,6 +8820,16 @@ fn translate_sse_event_to_anthropic_event(
             }
             if state.open_tool_index.is_some() {
                 return stop_anthropic_tool_block(state);
+            }
+            if state.has_tool_call_announced {
+                // The tool block was already streamed and closed by
+                // response.function_call_arguments.done, which arrives
+                // before response.output_item.done. Re-emitting it here
+                // would send a second tool_use block with the same id and
+                // Anthropic clients reject the message ("Invalid tool
+                // parameters" in Claude Code).
+                state.has_tool_call_announced = false;
+                return Vec::new();
             }
             let mut events = stop_anthropic_text_block(state);
             let arguments = item
@@ -11566,9 +11574,9 @@ mod tests {
             payload.get("instructions").and_then(Value::as_str),
             Some("You are terse.")
         );
-        assert_eq!(
-            payload.get("max_output_tokens").and_then(Value::as_i64),
-            Some(128)
+        assert!(
+            payload.get("max_output_tokens").is_none(),
+            "max_tokens must not be forwarded: the Codex upstream rejects max_output_tokens"
         );
         assert_eq!(
             payload.get("input").and_then(Value::as_array).map(Vec::len),
@@ -12497,6 +12505,120 @@ data: {"type":"response.completed","response":{"id":"resp_123","created_at":1,"m
                 .and_then(|value| value.get("type"))
                 .and_then(Value::as_str),
             Some("message_stop")
+        );
+    }
+
+    #[test]
+    fn anthropic_streamed_tool_call_emits_single_tool_use_block() {
+        let mut state = AnthropicStreamState::default();
+        let added = SseEvent {
+            event: Some("response.output_item.added".to_string()),
+            data: json!({
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "lookup_weather"
+                }
+            })
+            .to_string(),
+        };
+        let delta = SseEvent {
+            event: Some("response.function_call_arguments.delta".to_string()),
+            data: json!({
+                "type": "response.function_call_arguments.delta",
+                "delta": "{\"city\":\"Tokyo\"}"
+            })
+            .to_string(),
+        };
+        let arguments_done = SseEvent {
+            event: Some("response.function_call_arguments.done".to_string()),
+            data: json!({
+                "type": "response.function_call_arguments.done",
+                "arguments": "{\"city\":\"Tokyo\"}"
+            })
+            .to_string(),
+        };
+        let item_done = SseEvent {
+            event: Some("response.output_item.done".to_string()),
+            data: json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "lookup_weather",
+                    "arguments": "{\"city\":\"Tokyo\"}"
+                }
+            })
+            .to_string(),
+        };
+
+        let mut tool_block_starts = 0;
+        for event in [&added, &delta, &arguments_done, &item_done] {
+            for value in translate_sse_event_to_anthropic_event(event, &mut state) {
+                if value.get("type").and_then(Value::as_str) == Some("content_block_start")
+                    && value
+                        .get("content_block")
+                        .and_then(|block| block.get("type"))
+                        .and_then(Value::as_str)
+                        == Some("tool_use")
+                {
+                    tool_block_starts += 1;
+                }
+            }
+        }
+
+        assert_eq!(
+            tool_block_starts, 1,
+            "output_item.done must not re-emit a tool_use block that was already streamed"
+        );
+    }
+
+    #[test]
+    fn anthropic_single_shot_tool_item_emits_complete_block() {
+        let mut state = AnthropicStreamState::default();
+        let item_done = SseEvent {
+            event: Some("response.output_item.done".to_string()),
+            data: json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "call_id": "call_456",
+                    "name": "lookup_weather",
+                    "arguments": "{\"city\":\"Osaka\"}"
+                }
+            })
+            .to_string(),
+        };
+
+        let values = translate_sse_event_to_anthropic_event(&item_done, &mut state);
+        let starts: Vec<&Value> = values
+            .iter()
+            .filter(|value| {
+                value.get("type").and_then(Value::as_str) == Some("content_block_start")
+                    && value
+                        .get("content_block")
+                        .and_then(|block| block.get("type"))
+                        .and_then(Value::as_str)
+                        == Some("tool_use")
+            })
+            .collect();
+
+        assert_eq!(starts.len(), 1);
+        assert_eq!(
+            starts[0]
+                .get("content_block")
+                .and_then(|block| block.get("id"))
+                .and_then(Value::as_str),
+            Some("call_456")
+        );
+        assert_eq!(
+            starts[0]
+                .get("content_block")
+                .and_then(|block| block.get("input"))
+                .and_then(|input| input.get("city"))
+                .and_then(Value::as_str),
+            Some("Osaka")
         );
     }
 

--- a/src-tauri/src/proxy_service.rs
+++ b/src-tauri/src/proxy_service.rs
@@ -1912,6 +1912,7 @@ async fn anthropic_messages_handler(
             Err(response) => return response,
         };
     let session_affinity_key = request_session_affinity_key(&headers, &request_json);
+    let headers = apply_anthropic_upstream_session_id(headers, &request_json);
 
     let (upstream_payload, downstream_stream) =
         match convert_anthropic_messages_request_to_codex(&request_json) {
@@ -2744,6 +2745,49 @@ fn normalize_session_affinity_value(value: &str) -> Option<String> {
     }
 }
 
+// Claude Code does not send `session-id`/`session_id`, which the Codex upstream
+// expects for per-conversation routing; without it each request would otherwise
+// fall back to a random UUID and land on a random prompt-cache shard. Derive a
+// stable per-conversation identifier from the client-supplied session markers.
+const ANTHROPIC_SESSION_ID_HEADERS: &[&str] = &["x-claude-code-session-id", "x-claude-session-id"];
+
+fn anthropic_upstream_session_id(headers: &HeaderMap, request_json: &Value) -> Option<String> {
+    for name in ANTHROPIC_SESSION_ID_HEADERS {
+        if let Some(value) = headers
+            .get(*name)
+            .and_then(|value| value.to_str().ok())
+            .and_then(normalize_session_affinity_value)
+        {
+            return Some(value);
+        }
+    }
+
+    let user_id = request_json
+        .get("metadata")
+        .and_then(|metadata| metadata.get("user_id"))
+        .and_then(Value::as_str)?;
+    let parsed = serde_json::from_str::<Value>(user_id).ok()?;
+    parsed
+        .get("session_id")
+        .and_then(Value::as_str)
+        .and_then(normalize_session_affinity_value)
+}
+
+fn apply_anthropic_upstream_session_id(headers: HeaderMap, request_json: &Value) -> HeaderMap {
+    if headers.get("session-id").is_some() || headers.get("session_id").is_some() {
+        return headers;
+    }
+    let Some(session_id) = anthropic_upstream_session_id(&headers, request_json) else {
+        return headers;
+    };
+    let Ok(value) = HeaderValue::from_str(&session_id) else {
+        return headers;
+    };
+    let mut headers = headers;
+    headers.insert("session-id", value);
+    headers
+}
+
 fn invalid_request_response(message: &str) -> Response<Body> {
     let mut response = Json(json!({
         "error": {
@@ -3333,15 +3377,37 @@ fn convert_anthropic_messages_request_to_codex(request: &Value) -> Result<(Value
     Ok((Value::Object(root), downstream_stream))
 }
 
+const ANTHROPIC_BILLING_HEADER_LINE_PREFIX: &str = "x-anthropic-billing-header:";
+
+fn strip_anthropic_billing_header_lines(text: &str) -> String {
+    if !text
+        .lines()
+        .any(|line| line.trim_start().starts_with(ANTHROPIC_BILLING_HEADER_LINE_PREFIX))
+    {
+        return text.to_string();
+    }
+
+    text.lines()
+        .filter(|line| {
+            !line
+                .trim_start()
+                .starts_with(ANTHROPIC_BILLING_HEADER_LINE_PREFIX)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn anthropic_system_to_instructions(system: Option<&Value>) -> String {
     match system {
-        Some(Value::String(text)) => text.clone(),
+        Some(Value::String(text)) => strip_anthropic_billing_header_lines(text),
         Some(Value::Array(items)) => items
             .iter()
             .filter_map(|item| {
                 item.as_object()
                     .and_then(|object| object.get("text"))
                     .and_then(Value::as_str)
+                    .map(strip_anthropic_billing_header_lines)
+                    .filter(|text| !text.is_empty())
             })
             .collect::<Vec<_>>()
             .join("\n"),
@@ -9515,6 +9581,7 @@ fn parse_proxy_request_body_limit_mib(value: Option<&str>) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::account_to_proxy_candidate;
+    use super::anthropic_upstream_session_id;
     use super::api_proxy_disabled_model_set;
     use super::api_proxy_requested_models_from_payload;
     use super::api_proxy_usage_bucket_seconds;
@@ -9522,6 +9589,7 @@ mod tests {
     use super::api_proxy_visible_models;
     use super::api_proxy_visible_models_for_key;
     use super::append_api_proxy_usage_event;
+    use super::apply_anthropic_upstream_session_id;
     use super::build_api_proxy_usage_stats;
     use super::build_compact_sse_failure;
     use super::build_compact_sse_response;
@@ -12620,6 +12688,110 @@ data: {"type":"response.completed","response":{"id":"resp_123","created_at":1,"m
                 .and_then(Value::as_str),
             Some("Osaka")
         );
+    }
+
+    #[test]
+    fn anthropic_system_instructions_strip_billing_header() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "max_tokens": 128,
+            "system": [
+                {
+                    "type": "text",
+                    "text": "x-anthropic-billing-header: cc_version=2.1.116.a60; cc_entrypoint=cli; cch=2bb95;"
+                },
+                {"type": "text", "text": "You are a helpful assistant."}
+            ],
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+
+        let (upstream, _) = convert_anthropic_messages_request_to_codex(&request).unwrap();
+        let instructions = upstream
+            .get("instructions")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+
+        assert!(
+            !instructions.contains("x-anthropic-billing-header"),
+            "billing header must not leak into upstream instructions: {instructions}"
+        );
+        assert_eq!(instructions, "You are a helpful assistant.");
+    }
+
+    #[test]
+    fn anthropic_system_instructions_strip_billing_header_inside_block() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "max_tokens": 128,
+            "system": "preamble\nx-anthropic-billing-header: cc_version=2.1.116.a60; cch=2bb95;\nafterword",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+
+        let (upstream, _) = convert_anthropic_messages_request_to_codex(&request).unwrap();
+        let instructions = upstream
+            .get("instructions")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+
+        assert!(!instructions.contains("x-anthropic-billing-header"));
+        assert_eq!(instructions, "preamble\nafterword");
+    }
+
+    #[test]
+    fn anthropic_upstream_session_id_prefers_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-claude-code-session-id",
+            HeaderValue::from_static("0123abcd-1111-2222-3333-444455556666"),
+        );
+
+        let request = json!({
+            "metadata": {"user_id": "{\"session_id\":\"fallback-id\"}"}
+        });
+
+        assert_eq!(
+            anthropic_upstream_session_id(&headers, &request).as_deref(),
+            Some("0123abcd-1111-2222-3333-444455556666")
+        );
+    }
+
+    #[test]
+    fn anthropic_upstream_session_id_falls_back_to_metadata_user_id() {
+        let headers = HeaderMap::new();
+        let request = json!({
+            "metadata": {
+                "user_id": "{\"device_id\":\"abc\",\"account_uuid\":\"\",\"session_id\":\"095c1c3e-52f2-48bd-aa2a-c53d1cec6736\"}"
+            }
+        });
+
+        assert_eq!(
+            anthropic_upstream_session_id(&headers, &request).as_deref(),
+            Some("095c1c3e-52f2-48bd-aa2a-c53d1cec6736")
+        );
+    }
+
+    #[test]
+    fn apply_anthropic_upstream_session_id_inserts_header_once() {
+        let request = json!({
+            "metadata": {"user_id": "{\"session_id\":\"sid-from-metadata\"}"}
+        });
+
+        let headers = apply_anthropic_upstream_session_id(HeaderMap::new(), &request);
+        assert_eq!(
+            headers.get("session-id").and_then(|value| value.to_str().ok()),
+            Some("sid-from-metadata")
+        );
+
+        let mut existing = HeaderMap::new();
+        existing.insert("session-id", HeaderValue::from_static("client-provided"));
+        let headers = apply_anthropic_upstream_session_id(existing, &request);
+        assert_eq!(
+            headers.get("session-id").and_then(|value| value.to_str().ok()),
+            Some("client-provided")
+        );
+
+        let headers = apply_anthropic_upstream_session_id(HeaderMap::new(), &json!({}));
+        assert!(headers.get("session-id").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

在 Linux 上部署 `codex-tools-proxyd` v2.7.0，Claude Code 直连 `POST /v1/messages` 会遇到两个问题（复现环境：CC 2.1.116 + `gpt-5.6-sol`）：

### 1. 带必填 `max_tokens` 的请求全部 400

`convert_anthropic_messages_request_to_codex` 把 `max_tokens` 映射成 `max_output_tokens`，Codex 上游直接拒绝：

```
HTTP 400 {"detail":"Unsupported parameter: max_output_tokens"}
```

Anthropic 规范要求 `max_tokens` 必填，Claude Code 每个请求都会带，所以完全不可用。

### 2. 流式 tool_use 块重复 → Claude Code 报 "Invalid tool parameters"

上游 SSE 的实际顺序：

```
response.output_item.added             → 开 tool 块
response.function_call_arguments.delta × N
response.function_call_arguments.done  → 关 tool 块（stop_anthropic_tool_block）
response.output_item.done              → open_tool_index 已是 None
                                        → 走"块从未打开"分支
                                        → 用完整 arguments 再开一个同 id 的 tool_use 块
```

抓包可见同一个 `call_id` 出现两个 content_block（第一个由 input_json_delta 流式拼装，第二个携带完整 input、零 delta），Claude Code 对第二个块做参数校验时报 `Invalid tool parameters`。只要模型调用工具就必现。

## 修复

1. **不再转发 `max_tokens`**：请求仍接受该字段（Anthropic 客户端必填），只是不映射为 `max_output_tokens` 发给上游。
2. **给 Anthropic 流式翻译器加 `has_tool_call_announced` 防护**：与 chat-completions 翻译器（`translate_sse_event_to_chat_chunk` 处理 `response.output_item.done` 的 `has_tool_call_announced`）同样的做法——发现该 tool call 已经流式输出过就直接跳过，不再补发完整块。单独到达的 `output_item.done`（无 added/delta 前置）仍按原逻辑发完整块。

文档 `docs/api-proxy.md` 的兼容字段列表同步注明了 `max_tokens` 的行为。

## 验证

- 新增回归测试：
  - `anthropic_streamed_tool_call_emits_single_tool_use_block`（added + delta + args.done + item.done 只产生 1 个 tool_use 块）
  - `anthropic_single_shot_tool_item_emits_complete_block`（单独 item.done 仍发完整块）
- `cargo test` 145 个测试全过（含更新后的 `converts_anthropic_messages_request_to_codex_payload`）
- 真机部署验证（Debian 13，替换 binary 后）：
  - 带 `max_tokens` 直连 `/v1/messages` 返回 200（原先 400）
  - 流式 tool call 输出仅 1 个 tool_use content_block（原先 2 个同 id）
  - Claude Code `claude -p` + Bash 工具完整工具循环跑通