### PR TITLE
EN: Add ctc delete subcommand for removing stored accounts / ZH: 新增 ctc delete 子命令删除已保存账号

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Codex Tools 面向同时使用多个 Codex 账号的场景，提供桌面 GUI、
 - 多账号管理：OAuth 登录导入、JSON 批量导入、账号备份回导入。
 - 用量查看：展示 `5h`、`1week` 用量窗口和账号计划类型。
 - 快速切换：切换 `~/.codex/auth.json` 和 `config.toml`，可联动启动新版 ChatGPT App，并兼容旧 Codex App 与 `codex app` 回退。
-- CLI/TUI：通过 `ctc` 执行 `list/switch/login/import/export/usage/provider/doctor/report/tui`。
+- CLI/TUI：通过 `ctc` 执行 `list/switch/login/import/export/delete/usage/provider/doctor/report/tui`。
 - API 反代：本地提供 OpenAI 兼容 `/v1` 接口，支持运行中账号轮换。
 - App/CLI 绑定：可一键把 Codex App/CLI 切到本机反代地址，也可一键恢复原配置。
 - 公网访问：集成 cloudflared，支持快速隧道和命名隧道。
@@ -126,6 +126,8 @@ Windows 首次运行新版时也会显示额度展示引导。任务栏组件和
 | `ctc import --current --json` | 导入当前 `~/.codex/auth.json` |
 | `ctc export ./accounts.json --json` | 导出账号库 |
 | `ctc export --json` | 直接把账号库 JSON 输出到终端 |
+| `ctc delete 1` | 删除第 1 个账号（交互确认，`--yes` 跳过） |
+| `ctc delete <id> --yes` | 按 `ctc list --json` 中的内部 id 删除账号并跳过确认 |
 | `ctc usage --cached --json` | 查看本地缓存用量 |
 | `ctc provider status --json` | 查看当前 provider、rollout 和 `state_5.sqlite` provider 统计 |
 | `ctc provider sync` | 把本机 Codex 历史元数据同步到当前 provider |

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 2. Keep quota surfaces current with one coordinated 60-second native refresh, shared cached/error states, reduced freshness-only disk writes, Explorer restart recovery, fullscreen and auto-hide handling, and rate-limited Windows UI Automation scans.
 3. Recover genuinely newer rotated authorization snapshots without reviving stale refresh failures, and keep Windows preview credentials isolated from production account data.
 4. Restore the README Star History chart through a working no-token data source while the official GitHub stargazer endpoint remains restricted.
+5. Add the `ctc delete` CLI subcommand to remove a stored account by list index, internal id, or label, with an interactive confirmation prompt, a `--yes` bypass for scripts, ambiguity reporting for duplicated accounts, and automatic clearing of the active-account pointer.
 
 #### 中文
 
@@ -17,6 +18,7 @@
 2. 使用统一的原生 60 秒调度刷新所有额度展示，共享缓存和错误状态，减少仅新鲜度变化造成的磁盘写入，并支持 Explorer 重启恢复、全屏/自动隐藏处理及限频的 Windows UI Automation 扫描。
 3. 仅恢复确实更新且已轮换的授权快照，避免重新引入过期刷新失败；Windows 预览环境不再复制生产账号与授权数据。
 4. 在官方 GitHub stargazer 接口受限期间，改用可工作的免 Token 数据源恢复 README 的 Star History 图表。
+5. 新增 `ctc delete` CLI 子命令：可按列表序号、内部 id 或别名删除已保存账号，交互终端删除前提示确认、脚本场景可用 `--yes` 跳过，重复账号匹配不唯一时会列出候选，删除当前激活账号时自动清空 active 指针。
 
 - v2.6.0
 

--- a/how to use.md
+++ b/how to use.md
@@ -121,6 +121,8 @@ npx @170-carry/ctc list --json
 | `ctc import --current --json` | 导入当前 `~/.codex/auth.json` |
 | `ctc export ./accounts.json --json` | 导出账号库 |
 | `ctc export --json` | 直接把账号库 JSON 输出到终端 |
+| `ctc delete 1` | 删除第 1 个账号（交互确认，`--yes` 跳过） |
+| `ctc delete <id> --yes` | 按 `ctc list --json` 中的内部 id 删除账号并跳过确认 |
 | `ctc usage --cached --json` | 查看本地缓存用量 |
 | `ctc doctor --json` | 检查本地环境和账号库 |
 | `ctc report --json` | 输出完整诊断报告 |

--- a/npm/ctc/README.md
+++ b/npm/ctc/README.md
@@ -17,6 +17,7 @@ ctc switch --best --launch
 ctc login --label work
 ctc import ./auth.json
 ctc export ./accounts.json
+ctc delete 1
 ctc usage --cached --json
 ctc provider status --json
 ctc provider sync
@@ -28,6 +29,6 @@ ctc ui
 
 说明：
 
-- `ctc list/switch/login/import/export/usage/provider/doctor/report/tui` 会调用随 npm 安装的原生 `codex-tools-cli`。
+- `ctc list/switch/login/import/export/delete/usage/provider/doctor/report/tui` 会调用随 npm 安装的原生 `codex-tools-cli`。
 - `ctc ui` 会打开本机已安装的 Codex Tools 桌面应用；如果没有安装桌面应用，请先从 GitHub Releases 安装。
 - 如果安装时禁用了 optional dependencies，请重新安装：`npm i -g @170-carry/ctc --include=optional`。

--- a/src-tauri/src/account_service.rs
+++ b/src-tauri/src/account_service.rs
@@ -415,18 +415,7 @@ pub(crate) async fn delete_account_internal(
 ) -> Result<(), String> {
     let _guard = state.store_lock.lock().await;
     let mut store = load_store(app)?;
-    let removed_current = store.settings.active_account_id.as_deref() == Some(id);
-    let original_len = store.accounts.len();
-    store.accounts.retain(|account| account.id != id);
-
-    if original_len == store.accounts.len() {
-        return Err("未找到要删除的账号".to_string());
-    }
-
-    if removed_current {
-        store.settings.active_account_id = None;
-    }
-
+    store.delete_account_by_id(id)?;
     save_store(app, &store)?;
     Ok(())
 }

--- a/src-tauri/src/command_line.rs
+++ b/src-tauri/src/command_line.rs
@@ -32,7 +32,8 @@ use crate::usage;
 use crate::utils;
 
 const CLI_COMMANDS: &[&str] = &[
-    "list", "switch", "login", "import", "export", "usage", "provider", "doctor", "report", "tui",
+    "list", "switch", "login", "import", "export", "delete", "usage", "provider", "doctor",
+    "report", "tui",
 ];
 
 #[derive(Debug, Parser)]
@@ -91,6 +92,14 @@ enum CliCommand {
         output: Option<PathBuf>,
         #[arg(long, value_name = "ACCOUNT")]
         account: Option<String>,
+    },
+    /// Delete a stored account by list index, id, or label.
+    Delete {
+        #[arg(value_name = "ACCOUNT")]
+        account: String,
+        /// Skip the interactive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
     },
     /// Refresh or show usage for stored accounts.
     Usage {
@@ -156,6 +165,12 @@ struct CliLoginResult {
 struct CliExportResult {
     account_count: usize,
     output_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CliDeleteResult {
+    account: AccountSummary,
 }
 
 #[derive(Debug, Serialize)]
@@ -342,6 +357,19 @@ async fn run_cli(args: CliArgs) -> Result<(), String> {
                 );
                 Ok(())
             } else {
+                Ok(())
+            }
+        }
+        CliCommand::Delete { account, yes } => {
+            let result = delete_account(&store_path, &account, yes)?;
+            if args.json {
+                print_json(&result)
+            } else {
+                println!(
+                    "deleted {} ({})",
+                    result.account.label,
+                    utils::short_account(&result.account.account_id)
+                );
                 Ok(())
             }
         }
@@ -617,6 +645,60 @@ fn launch_codex(configured_path: Option<&str>, workspace: Option<&Path>) -> Resu
         .spawn()
         .map_err(|error| format!("启动 codex app 失败: {error}"))?;
     Ok(())
+}
+
+fn delete_account(
+    store_path: &Path,
+    account_ref: &str,
+    assume_yes: bool,
+) -> Result<CliDeleteResult, String> {
+    let mut store = store::load_store_from_path(store_path)?;
+    let summaries = account_summaries(&store);
+    let selected_index =
+        resolve_single_account_index(&store, &summaries, Some(account_ref), false)?;
+    let summary = summaries
+        .get(selected_index)
+        .cloned()
+        .ok_or_else(|| "找不到要删除的账号".to_string())?;
+
+    if !assume_yes {
+        confirm_account_deletion(
+            &summary.label,
+            &summary.account_id,
+            io::stdin().is_terminal(),
+        )?;
+    }
+
+    store.delete_account_by_id(&summary.id)?;
+    store::save_store_to_path(store_path, &store)?;
+    Ok(CliDeleteResult { account: summary })
+}
+
+fn confirm_account_deletion(
+    label: &str,
+    account_id: &str,
+    interactive: bool,
+) -> Result<(), String> {
+    if !interactive {
+        return Err("非交互终端删除账号需要显式传入 --yes 确认".to_string());
+    }
+    print!(
+        "确认删除账号 {} ({})? [y/N]: ",
+        label,
+        utils::short_account(account_id)
+    );
+    io::stdout()
+        .flush()
+        .map_err(|error| format!("刷新终端输出失败: {error}"))?;
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .map_err(|error| format!("读取终端输入失败: {error}"))?;
+    if matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        Ok(())
+    } else {
+        Err("已取消删除".to_string())
+    }
 }
 
 async fn login_account(
@@ -1307,8 +1389,18 @@ fn is_cli_auth_expired_error(raw_error: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::confirm_account_deletion;
+    use super::delete_account;
     use super::is_cli_invocation;
+    use crate::models::AccountsStore;
+    use crate::models::StoredAccount;
+    use crate::store;
+    use serde_json::json;
     use std::ffi::OsString;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use uuid::Uuid;
 
     #[test]
     fn detects_direct_and_prefixed_cli_invocations() {
@@ -1325,6 +1417,157 @@ mod tests {
             OsString::from("codex-tools"),
             OsString::from("provider"),
         ]));
+        assert!(is_cli_invocation(&[
+            OsString::from("codex-tools"),
+            OsString::from("delete"),
+        ]));
         assert!(!is_cli_invocation(&[OsString::from("codex-tools")]));
+    }
+
+    fn temp_store_path() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("codex-tools-cli-test-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir.join("accounts.json")
+    }
+
+    fn cleanup_store(path: &Path) {
+        if let Some(dir) = path.parent() {
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    fn sample_account(id: &str, label: &str, account_id: &str) -> StoredAccount {
+        StoredAccount {
+            id: id.to_string(),
+            label: label.to_string(),
+            source_kind: Default::default(),
+            principal_id: Some(format!("{label}@example.com")),
+            email: Some(format!("{label}@example.com")),
+            account_id: account_id.to_string(),
+            plan_type: Some("plus".to_string()),
+            auth_json: json!({ "kind": label }),
+            api_base_url: None,
+            api_key: None,
+            model_name: None,
+            balance_text: None,
+            profile_auth_path: None,
+            profile_config_path: None,
+            profile_auth_ready: false,
+            profile_config_ready: false,
+            profile_integrity_error: None,
+            profile_last_validated_at: None,
+            profile_last_validation_error: None,
+            added_at: 0,
+            updated_at: 0,
+            usage: None,
+            usage_error: None,
+            auth_refresh_blocked: false,
+            auth_refresh_error: None,
+            api_proxy_enabled: true,
+        }
+    }
+
+    fn store_with_accounts(accounts: Vec<StoredAccount>, active_id: Option<&str>) -> AccountsStore {
+        let mut store = AccountsStore {
+            accounts,
+            ..AccountsStore::default()
+        };
+        store.settings.active_account_id = active_id.map(str::to_string);
+        store
+    }
+
+    #[test]
+    fn delete_account_by_display_index_removes_entry_and_clears_active() {
+        let path = temp_store_path();
+        let store = store_with_accounts(
+            vec![
+                sample_account("id-alpha", "alpha", "acct-alpha-0001"),
+                sample_account("id-beta", "beta", "acct-beta-00002"),
+            ],
+            Some("id-alpha"),
+        );
+        store::save_store_to_path(&path, &store).expect("save store");
+
+        let result = delete_account(&path, "1", true).expect("delete first account");
+        assert_eq!(result.account.id, "id-alpha");
+
+        let store = store::load_store_from_path(&path).expect("load store");
+        assert_eq!(store.accounts.len(), 1);
+        assert_eq!(store.accounts[0].id, "id-beta");
+        assert_eq!(store.settings.active_account_id, None);
+
+        cleanup_store(&path);
+    }
+
+    #[test]
+    fn delete_account_keeps_active_when_other_account_removed() {
+        let path = temp_store_path();
+        let store = store_with_accounts(
+            vec![
+                sample_account("id-alpha", "alpha", "acct-alpha-0001"),
+                sample_account("id-beta", "beta", "acct-beta-00002"),
+            ],
+            Some("id-beta"),
+        );
+        store::save_store_to_path(&path, &store).expect("save store");
+
+        delete_account(&path, "1", true).expect("delete first account");
+
+        let store = store::load_store_from_path(&path).expect("load store");
+        assert_eq!(store.accounts.len(), 1);
+        assert_eq!(store.settings.active_account_id.as_deref(), Some("id-beta"));
+
+        cleanup_store(&path);
+    }
+
+    #[test]
+    fn delete_account_with_duplicate_account_id_requires_unique_ref() {
+        let path = temp_store_path();
+        let store = store_with_accounts(
+            vec![
+                sample_account("id-dup-a", "dup-a", "acct-duplicate-01"),
+                sample_account("id-dup-b", "dup-b", "acct-duplicate-01"),
+            ],
+            None,
+        );
+        store::save_store_to_path(&path, &store).expect("save store");
+
+        let error = delete_account(&path, "acct-duplicate-01", true)
+            .expect_err("duplicate account_id should be ambiguous");
+        assert!(error.contains("账号匹配不唯一"));
+
+        let result = delete_account(&path, "id-dup-a", true).expect("delete by internal id");
+        assert_eq!(result.account.id, "id-dup-a");
+
+        let store = store::load_store_from_path(&path).expect("load store");
+        assert_eq!(store.accounts.len(), 1);
+        assert_eq!(store.accounts[0].id, "id-dup-b");
+
+        cleanup_store(&path);
+    }
+
+    #[test]
+    fn delete_account_rejects_unknown_ref() {
+        let path = temp_store_path();
+        let store = store_with_accounts(
+            vec![sample_account("id-alpha", "alpha", "acct-alpha-0001")],
+            None,
+        );
+        store::save_store_to_path(&path, &store).expect("save store");
+
+        let error = delete_account(&path, "missing", true).expect_err("unknown ref should fail");
+        assert!(error.contains("找不到账号"));
+
+        let store = store::load_store_from_path(&path).expect("load store");
+        assert_eq!(store.accounts.len(), 1);
+
+        cleanup_store(&path);
+    }
+
+    #[test]
+    fn delete_account_requires_yes_in_non_interactive_terminal() {
+        let error = confirm_account_deletion("alpha", "acct-alpha-0001", false)
+            .expect_err("non-interactive delete should require --yes");
+        assert!(error.contains("--yes"));
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -58,6 +58,21 @@ impl Default for AccountsStore {
     }
 }
 
+impl AccountsStore {
+    /// 按内部 id 删除已保存账号，返回被删除的账号。
+    /// 若删除的是当前激活账号，则同时清空 active 指针，避免引用不存在的条目。
+    pub(crate) fn delete_account_by_id(&mut self, id: &str) -> Result<StoredAccount, String> {
+        let Some(index) = self.accounts.iter().position(|account| account.id == id) else {
+            return Err("未找到要删除的账号".to_string());
+        };
+        let removed = self.accounts.remove(index);
+        if self.settings.active_account_id.as_deref() == Some(id) {
+            self.settings.active_account_id = None;
+        }
+        Ok(removed)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum AccountSourceKind {


### PR DESCRIPTION
## Summary / 概述

EN: Add a `ctc delete` CLI subcommand to remove a stored account from the account library, e.g. duplicated entries created by re-login.

ZH: 新增 `ctc delete` CLI 子命令，用于删除账号库中已保存的账号（例如重复登录产生的重复条目）。

## Changes / 改动

- `ctc delete <ACCOUNT>` resolves the target with the same semantics as `ctc switch`: list index, internal id, account_id, account_key, or label. Ambiguous matches (e.g. duplicated accounts sharing the same short id) report all candidates instead of deleting silently. / 账号解析与 `ctc switch` 语义一致：支持列表序号、内部 id、account_id、account_key、label；匹配不唯一时列出候选而不是误删。
- Interactive terminals prompt `y/N` before deleting; `--yes` skips the prompt, and non-interactive shells without `--yes` fail fast. / 交互终端删除前提示 `y/N` 确认，`--yes` 跳过；非交互终端未传 `--yes` 直接报错。
- Deleting the active account clears `settings.activeAccountId`; `~/.codex/auth.json` is left untouched, matching the desktop GUI behavior. / 删除激活账号时自动清空 `settings.activeAccountId`；不改动 `~/.codex/auth.json`，与桌面端删除行为一致。
- `--json` prints the deleted account summary. / `--json` 输出被删除账号的完整摘要。
- The desktop GUI `delete_account` command and the CLI now share one `AccountsStore::delete_account_by_id` implementation. / 桌面端 `delete_account` 与 CLI 共用 `AccountsStore::delete_account_by_id` 实现，逻辑不再分叉。
- Docs updated: README, npm/ctc README, how-to-use guide, changelog. / 已更新 README、npm/ctc README、使用文档与更新日志。

## Tests / 测试

- 6 new unit tests covering index deletion, active-pointer clearing/preservation, duplicate-account ambiguity, unknown refs, non-interactive `--yes` gating, and CLI routing; `cargo test --lib`: 246 passed. / 新增 6 个单测，覆盖序号删除、active 指针清理与保留、重复账号歧义报错、未知引用、非交互终端 `--yes` 校验、CLI 路由识别；`cargo test --lib` 246 个测试全部通过。
- End-to-end smoke test with a duplicated-account store: non-TTY refusal, ambiguity report, delete by internal id, and active pointer reset all verified. / 使用含重复账号的存储做了端到端冒烟验证：非交互拒绝、歧义候选提示、按内部 id 精确删除、激活指针清空均符合预期。