### PR TITLE
[EN/ZH] Fix quota mirroring and usage scan panic / 修复额度覆盖与用量扫描崩溃

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -245,33 +245,6 @@ pub(crate) struct UsageWindow {
     pub(crate) reset_at: Option<i64>,
 }
 
-pub(crate) fn align_zero_five_hour_usage_with_weekly(snapshot: &mut UsageSnapshot) -> bool {
-    const FIVE_HOURS_SECONDS: i64 = 5 * 60 * 60;
-    const ONE_WEEK_SECONDS: i64 = 7 * 24 * 60 * 60;
-
-    let Some(one_week) = snapshot.one_week.as_ref() else {
-        return false;
-    };
-    if one_week.window_seconds < ONE_WEEK_SECONDS || one_week.used_percent <= f64::EPSILON {
-        return false;
-    }
-    let weekly_used_percent = one_week.used_percent.clamp(0.0, 100.0);
-
-    let Some(five_hour) = snapshot.five_hour.as_mut() else {
-        return false;
-    };
-    if five_hour.window_seconds != FIVE_HOURS_SECONDS || five_hour.used_percent.abs() > f64::EPSILON
-    {
-        return false;
-    }
-
-    // The current usage API can retain a zero-valued 5h-shaped placeholder
-    // after the 5h limit is removed. Keep the legacy surface meaningful by
-    // mirroring the weekly usage until the API exposes an explicit capability.
-    five_hour.used_percent = weekly_used_percent;
-    true
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CreditSnapshot {
@@ -1091,7 +1064,6 @@ fn duplicate_account_merge_score(account: &StoredAccount) -> (u8, u8, u8, u8, i6
 
 #[cfg(test)]
 mod tests {
-    use super::align_zero_five_hour_usage_with_weekly;
     use super::dedupe_account_variants;
     use super::mark_current_account_summary;
     use super::AppSettings;
@@ -1124,26 +1096,6 @@ mod tests {
             credits: None,
             reset_credits: None,
         }
-    }
-
-    #[test]
-    fn zero_five_hour_placeholder_tracks_weekly_usage() {
-        let mut snapshot = usage_snapshot("pro");
-        snapshot.five_hour.as_mut().unwrap().used_percent = 0.0;
-        snapshot.one_week.as_mut().unwrap().used_percent = 37.0;
-
-        assert!(align_zero_five_hour_usage_with_weekly(&mut snapshot));
-        assert_eq!(snapshot.five_hour.unwrap().used_percent, 37.0);
-    }
-
-    #[test]
-    fn nonzero_five_hour_usage_remains_independent() {
-        let mut snapshot = usage_snapshot("pro");
-        snapshot.five_hour.as_mut().unwrap().used_percent = 4.0;
-        snapshot.one_week.as_mut().unwrap().used_percent = 37.0;
-
-        assert!(!align_zero_five_hour_usage_with_weekly(&mut snapshot));
-        assert_eq!(snapshot.five_hour.unwrap().used_percent, 4.0);
     }
 
     #[test]

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -16,7 +16,6 @@ use crate::auth::extract_auth;
 use crate::auth::has_newer_auth_refresh_snapshot;
 use crate::auth::read_current_codex_auth_optional;
 use crate::auth::write_active_codex_auth;
-use crate::models::align_zero_five_hour_usage_with_weekly;
 use crate::models::dedupe_account_variants;
 use crate::models::AccountSourceKind;
 use crate::models::AccountsStore;
@@ -371,14 +370,6 @@ fn normalize_loaded_store(path: &Path, mut store: AccountsStore) -> AccountsStor
     }
 
     for account in &mut store.accounts {
-        if account
-            .usage
-            .as_mut()
-            .is_some_and(align_zero_five_hour_usage_with_weekly)
-        {
-            changed = true;
-        }
-
         if account
             .principal_id
             .as_deref()
@@ -901,32 +892,32 @@ mod tests {
     }
 
     #[test]
-    fn loading_store_persists_zero_five_hour_placeholder_alignment() {
+    fn loading_store_preserves_zero_five_hour_usage() {
         let dir = temp_dir();
         let store_path = dir.join("accounts.json");
-        let mut store = sample_store("usage-placeholder", "workspace-usage", 10);
-        let mut usage = usage_snapshot("pro");
+        let mut store = sample_store("zero-five-hour", "workspace-usage", 10);
+        let mut usage = usage_snapshot("plus");
         usage.five_hour.as_mut().unwrap().used_percent = 0.0;
         usage.one_week.as_mut().unwrap().used_percent = 31.0;
         store.accounts[0].usage = Some(usage);
-        save_store_to_path(&store_path, &store).expect("save placeholder store");
+        save_store_to_path(&store_path, &store).expect("save usage store");
 
-        let loaded = load_store_from_path(&store_path).expect("load normalized store");
+        let loaded = load_store_from_path(&store_path).expect("load usage store");
         assert_eq!(
             loaded.accounts[0]
                 .usage
                 .as_ref()
                 .and_then(|usage| usage.five_hour.as_ref())
                 .map(|window| window.used_percent),
-            Some(31.0)
+            Some(0.0)
         );
 
         let persisted: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(&store_path).expect("read normalized store"))
-                .expect("parse normalized store");
+            serde_json::from_str(&fs::read_to_string(&store_path).expect("read usage store"))
+                .expect("parse usage store");
         assert_eq!(
             persisted["accounts"][0]["usage"]["fiveHour"]["usedPercent"],
-            31.0
+            0.0
         );
     }
 

--- a/src-tauri/src/token_usage.rs
+++ b/src-tauri/src/token_usage.rs
@@ -618,14 +618,21 @@ fn matching_record_boundary(child: &[u64], parent: &[u64], resync_window: usize)
         // envelope records. Re-synchronise only after a run of normalized,
         // high-entropy records confirms the alignment, so a genuine branch
         // point remains a conservative stop boundary.
-        let child_search_end = child
-            .len()
-            .saturating_sub(FORK_MATCH_ANCHOR_RECORDS)
-            .min(child_index.saturating_add(resync_window));
-        let parent_search_end = parent
-            .len()
-            .saturating_sub(FORK_MATCH_ANCHOR_RECORDS)
-            .min(parent_index.saturating_add(resync_window));
+        let Some(child_last_anchor_start) = child.len().checked_sub(FORK_MATCH_ANCHOR_RECORDS)
+        else {
+            break;
+        };
+        let Some(parent_last_anchor_start) = parent.len().checked_sub(FORK_MATCH_ANCHOR_RECORDS)
+        else {
+            break;
+        };
+        if child_index > child_last_anchor_start || parent_index > parent_last_anchor_start {
+            break;
+        }
+        let child_search_end =
+            child_last_anchor_start.min(child_index.saturating_add(resync_window));
+        let parent_search_end =
+            parent_last_anchor_start.min(parent_index.saturating_add(resync_window));
         let mut best_alignment = None::<(usize, usize, usize)>;
         for next_child in child_index..=child_search_end {
             for next_parent in parent_index..=parent_search_end {
@@ -3415,6 +3422,22 @@ mod tests {
         assert_eq!(
             matching_record_prefix(&child, &parent, FORK_MATCH_RESYNC_WINDOW),
             3
+        );
+    }
+
+    #[test]
+    fn fork_record_matching_short_mismatch_stops_without_panicking() {
+        assert_eq!(
+            matching_record_prefix(&[1], &[2], FORK_MATCH_RESYNC_WINDOW),
+            0
+        );
+        assert_eq!(
+            matching_record_prefix(&[1], &[2, 3, 4, 5, 6], FORK_MATCH_RESYNC_WINDOW),
+            0
+        );
+        assert_eq!(
+            matching_record_prefix(&[1, 2, 3, 4, 5], &[6], FORK_MATCH_RESYNC_WINDOW),
+            0
         );
     }
 

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -2,7 +2,6 @@ use serde::Deserialize;
 use std::error::Error as StdError;
 
 use crate::app_paths;
-use crate::models::align_zero_five_hour_usage_with_weekly;
 use crate::models::CreditSnapshot;
 use crate::models::ResetCredit;
 use crate::models::ResetCreditsSnapshot;
@@ -303,7 +302,9 @@ fn map_usage_payload(
     let five_hour = pick_nearest_window(&windows, 5 * 60 * 60).map(to_usage_window);
     let one_week = pick_nearest_window(&windows, 7 * 24 * 60 * 60).map(to_usage_window);
 
-    let mut snapshot = UsageSnapshot {
+    // A zero percentage is a valid freshly reset window. Keep each API window
+    // independent instead of inferring one window's value from another.
+    UsageSnapshot {
         fetched_at: now_unix_seconds(),
         plan_type: payload.plan_type,
         five_hour,
@@ -314,9 +315,7 @@ fn map_usage_payload(
             balance: credit.balance,
         }),
         reset_credits,
-    };
-    align_zero_five_hour_usage_with_weekly(&mut snapshot);
-    snapshot
+    }
 }
 
 fn map_reset_credits_payload(payload: serde_json::Value) -> ResetCreditsSnapshot {
@@ -426,7 +425,65 @@ fn to_usage_window(window: UsageWindowRaw) -> UsageWindow {
 #[cfg(test)]
 mod tests {
     use super::map_reset_credits_payload;
+    use super::map_usage_payload;
+    use super::RateLimitDetails;
+    use super::UsageApiResponse;
+    use super::UsageWindowRaw;
     use serde_json::json;
+
+    #[test]
+    fn zero_five_hour_window_remains_independent_from_weekly_usage() {
+        let snapshot = map_usage_payload(
+            UsageApiResponse {
+                plan_type: Some("plus".to_string()),
+                rate_limit: Some(RateLimitDetails {
+                    primary_window: Some(UsageWindowRaw {
+                        used_percent: 0.0,
+                        limit_window_seconds: 5 * 60 * 60,
+                        reset_at: 1_800,
+                    }),
+                    secondary_window: Some(UsageWindowRaw {
+                        used_percent: 37.0,
+                        limit_window_seconds: 7 * 24 * 60 * 60,
+                        reset_at: 604_800,
+                    }),
+                }),
+                additional_rate_limits: None,
+                credits: None,
+            },
+            None,
+        );
+
+        assert_eq!(snapshot.five_hour.unwrap().used_percent, 0.0);
+        assert_eq!(snapshot.one_week.unwrap().used_percent, 37.0);
+    }
+
+    #[test]
+    fn nonzero_five_hour_window_remains_independent_from_weekly_usage() {
+        let snapshot = map_usage_payload(
+            UsageApiResponse {
+                plan_type: Some("plus".to_string()),
+                rate_limit: Some(RateLimitDetails {
+                    primary_window: Some(UsageWindowRaw {
+                        used_percent: 12.0,
+                        limit_window_seconds: 5 * 60 * 60,
+                        reset_at: 1_800,
+                    }),
+                    secondary_window: Some(UsageWindowRaw {
+                        used_percent: 37.0,
+                        limit_window_seconds: 7 * 24 * 60 * 60,
+                        reset_at: 604_800,
+                    }),
+                }),
+                additional_rate_limits: None,
+                credits: None,
+            },
+            None,
+        );
+
+        assert_eq!(snapshot.five_hour.unwrap().used_percent, 12.0);
+        assert_eq!(snapshot.one_week.unwrap().used_percent, 37.0);
+    }
 
     #[test]
     fn reset_credits_payload_accepts_common_timestamp_shapes() {


### PR DESCRIPTION
## English

### Problem and fix

- #193: the legacy zero-window workaround overwrote a valid 5-hour usage value of 0% with weekly usage, both after API refresh and when loading stored accounts. Remove this inference and preserve each API window independently. Add zero/nonzero Plus mapping coverage and a store-loading regression test.
- #194: fork-record resynchronization could attempt a four-record slice on a shorter record sequence. Check that a complete anchor fits on both sides before searching; stop conservatively when it does not. Add short child/parent mismatch regression coverage.

### Validation

- Rust suite: 279 passed. Frontend tests: 18 passed. Formatting and diff checks passed; frontend lint passed with 4 existing warnings.
- Production frontend and Windows release builds passed. The desktop UI validation used the release binary with `tauri/custom-protocol` and embedded frontend assets.
- Real Windows Plus reproduction after reset: API returned 5-hour/weekly usage of **0% / 63%**, while the installed old application displayed **63% / 63%**.
- After the account incurred new usage, the patched application, persisted snapshot, and live API agreed on **27% / 67%**. The patched Pro page also preserved **0% / 58%**.
- On the same machine, the old application's analysis page showed `range end index 4 out of range for slice of length 1` and the homepage failed to read token usage. The patched release restored homepage totals and completed the analysis page scan of 39 session files.
- Release CLI scan: 39 source files, 10,732 events, zero failed paths, no token-usage error.
- Local MSI/NSIS builds and an isolated install/upgrade exercise passed. Existing active authentication/configuration file hashes were unchanged during the final desktop check.

### Limits

- The live Plus account accumulated usage while the release build was running, so a patched Plus UI screenshot at exactly 0% was not captured. The old-version zero-value reproduction, patched nonzero live comparison, zero-value regressions, and patched Pro zero-value UI check are separate evidence.
- Installer testing was local and unsigned; updater signing could not be validated without the release signing key. The scan still reported unresolved fork/usage records; this change fixes the panic, not all analytics coverage limitations.

Addresses #193. Fixes #194.

## 中文

### 问题与修复

- #193：旧的零值窗口兼容逻辑会把有效的五小时已用 0% 覆盖成周用量，接口刷新和加载账号存储时都会触发。移除这一推断，独立保留各接口窗口；补充 Plus 零值/非零值映射与存储加载回归测试。
- #194：分叉记录重新对齐时，可能在不足四条记录的序列上截取四条记录。搜索前检查两侧是否都能容纳完整锚点，不满足时保守停止；补充子/父序列过短且不匹配的回归测试。

### 验证

- Rust 测试 279 项通过，前端测试 18 项通过；格式和 diff 检查通过，前端 lint 通过（4 条既有警告）。
- 生产前端及 Windows release 构建通过。桌面界面验收使用启用 `tauri/custom-protocol`、内嵌前端资源的 release 程序。
- Windows 真实 Plus 重置后复现：接口返回五小时/周已用量 **0% / 63%**，已安装旧版却显示 **63% / 63%**。
- 账号产生新消耗后，修复版页面、存储快照和实时接口一致为 **27% / 67%**；修复版 Pro 页面也正确保留 **0% / 58%**。
- 同一台机器上，旧版分析页报 `range end index 4 out of range for slice of length 1`，主页 Token 用量读取失败。修复版恢复主页统计，分析页完成 39 个会话文件的扫描。
- Release CLI 扫描：39 个源文件、10,732 个事件、失败路径为零，无 Token 用量读取错误。
- 本地 MSI/NSIS 构建及隔离安装/升级验证通过。最终桌面检查前后，当前授权与配置文件哈希未变。

### 验证边界

- Release 构建期间真实 Plus 账号已有新消耗，因此未捕获修复版 Plus 恰好为 0% 的界面。旧版零值复现、修复版非零实时对照、零值回归测试、修复版 Pro 零值界面是分别取得的证据。
- 安装验证使用本地未签名产物，缺少发布签名密钥，未验证更新器签名。扫描仍报告部分未解析的分叉/用量记录；本次修复越界崩溃，不代表解决全部统计覆盖边界。

对应 #193，修复 #194。
